### PR TITLE
fix(scanner): don't flag f-string interpolation or SCREAMING_SNAKE paths (#19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gforge",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A git firewall: a global pre-commit hook that blocks commits containing secrets (passwords, keys, tokens, .env files) across macOS, Linux, and Windows.",
   "keywords": [
     "git",

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -66,6 +66,9 @@ const VALUE_REFERENCE_ROOT_RE = /^(process|import|globalThis|window|os|System|De
 // literal (flag) rather than a reference/placeholder (ignore).
 export function looksLikeHardcodedSecret(rawValue, options = {}) {
   let value = String(rawValue).trim();
+  // A language string-prefix (Python f/r/b/u and combinations) directly before a
+  // quote: strip it so the quote is recognized, e.g. f"Bearer {token}", rb'...'.
+  value = value.replace(/^(?:[fFrRbBuU]{1,2})(?=["'`])/, "");
   const quote = value[0];
   const quoted = quote === '"' || quote === "'" || quote === "`";
   if (quoted) {
@@ -77,8 +80,10 @@ export function looksLikeHardcodedSecret(rawValue, options = {}) {
   value = value.trim();
 
   if (value.length < 4) return false;
-  // Interpolations / template placeholders are references regardless of quoting.
-  if (/\$\{|\{\{|%\(|<%|#\{/.test(value)) return false;
+  // Interpolations / template placeholders are references, not literals:
+  // ${...}, {{...}}, %(...)s, <%...%>, #{...}, and single-brace {ident} used by
+  // Python f-strings and C# interpolated strings (e.g. `Bearer {token}`).
+  if (/\$\{|\{\{|%\(|<%|#\{|\{[A-Za-z_][\w.]*\}/.test(value)) return false;
   if (!quoted) {
     // Unquoted expressions: shell vars, member access, function calls, env lookups.
     if (value.startsWith("$")) return false;
@@ -170,8 +175,8 @@ const ENTROPY_TOKEN = /[A-Za-z0-9+/=_-]{20,}/g;
 const PATH_SEGMENT = /^\.?[A-Za-z][A-Za-z0-9_.-]*$/;
 const PATH_SEGMENT_MAX_DIGITS = 2;
 const PATH_SEGMENT_MAX_DIGIT_RATIO = 0.15;
-const PATH_MIN_LOWERCASE_RATIO = 0.55;
 const IDENTIFIER_MIN_VOWEL_RATIO = 0.3; // English words ~40% vowels; random secrets ~16%
+const NAME_SEGMENT_MIN_CHECK_LENGTH = 8; // shorter path segments (src, api, v2) can't be secrets
 const LOCKFILE_NAMES = new Set([
   "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml",
   "composer.lock", "gemfile.lock", "go.sum", "cargo.lock", "poetry.lock",
@@ -201,6 +206,20 @@ function isPathSegment(segment) {
   return digits <= PATH_SEGMENT_MAX_DIGITS || digits / segment.length <= PATH_SEGMENT_MAX_DIGIT_RATIO;
 }
 
+// A segment that reads as a name, not random base64. It must be identifier-shaped
+// with few digits (isPathSegment); then a short segment (src, api, v2, js) can
+// never be a meaningful secret, a SCREAMING_SNAKE_CASE word (BACKEND_DIR) is a
+// clean const/env name, and any longer segment must be vowel-rich like a real
+// word. Random base64 segments are long, ~19% vowels, and mixed-case, so they
+// fail every branch (see issue #19).
+function looksLikeNameSegment(segment) {
+  if (!isPathSegment(segment)) return false;
+  if (segment.length < NAME_SEGMENT_MIN_CHECK_LENGTH) return true;
+  if (/^[A-Z][A-Z0-9_]*$/.test(segment)) return true;
+  const letters = segment.replace(/[^A-Za-z]/g, "");
+  return letters.length > 0 && ratioOf(letters, /[aeiouAEIOU]/g) >= IDENTIFIER_MIN_VOWEL_RATIO;
+}
+
 // `/` belongs in ENTROPY_TOKEN because base64 secrets use it — but that also
 // makes an entire import path one token, and the concatenation scores far above
 // the bare name (`src/components/GlobalFilterSidebar/GlobalFilterSummaryTrigger`
@@ -220,9 +239,11 @@ function isPathSegment(segment) {
 function looksLikePath(token) {
   if (!token.includes("/")) return false;
   const segments = token.split("/").filter(Boolean);
-  if (segments.length < 2 || !segments.every(isPathSegment)) return false;
-  const alphanumeric = token.replace(/[^A-Za-z0-9]/g, "");
-  return ratioOf(alphanumeric, /[a-z]/g) >= PATH_MIN_LOWERCASE_RATIO;
+  if (segments.length < 2) return false;
+  // Every segment must read as a name (word or SCREAMING_SNAKE), not base64. This
+  // replaces the whole-token lowercase-ratio gate, which mis-rejected paths that
+  // contain an all-caps segment such as $BACKEND_DIR/requirements (issue #19).
+  return segments.every(looksLikeNameSegment);
 }
 
 // The strings actually scored for one matched token: a path's segments, or the

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -178,16 +178,36 @@ test("entropyCandidates decomposes paths and leaves opaque tokens whole", () => 
     "modules",
     "webhook-implementation"
   ]);
-  // Not paths: no separator, a single segment, digit-dense segments, and
-  // uppercase-heavy tokens are all scored whole.
+  // Not paths: no separator, a single segment, base64 padding (=), or a segment
+  // that is long and random rather than a name are all scored whole.
   assert.deepEqual(entropyCandidates(AWS_SECRET_KEY), [AWS_SECRET_KEY]);
   assert.deepEqual(entropyCandidates(B64URL_TOKEN), [B64URL_TOKEN]);
   assert.deepEqual(entropyCandidates("Zx9Kq2mVbN7pLwR4tYaSdFgHjKlPoIuY"), ["Zx9Kq2mVbN7pLwR4tYaSdFgHjKlPoIuY"]);
   assert.deepEqual(entropyCandidates("/onlyonesegmentislongenough"), ["/onlyonesegmentislongenough"]);
   assert.deepEqual(entropyCandidates("aGVsbG8=/d29ybGQ="), ["aGVsbG8=/d29ybGQ="]);
+  // SCREAMING_SNAKE_CASE segments are clean const/env names, not base64 (which is
+  // mixed-case), so an all-caps path decomposes per-segment too (issue #19).
   assert.deepEqual(entropyCandidates("SRC/COMPONENTS/GLOBALFILTERSUMMARYTRIGGER"), [
-    "SRC/COMPONENTS/GLOBALFILTERSUMMARYTRIGGER"
+    "SRC",
+    "COMPONENTS",
+    "GLOBALFILTERSUMMARYTRIGGER"
   ]);
+});
+
+test("issue #19: f-string interpolation and SCREAMING_SNAKE path segments are not secrets", () => {
+  // 1) f-string / interpolated-string values are references, not literals.
+  assert.equal(ruleIds("voice_changer.py", `    headers = {"Authorization": f"Bearer {token}"}`).length, 0);
+  assert.equal(ruleIds("a.py", `auth = f"Bearer {access_token}"`).length, 0);
+  assert.equal(ruleIds("a.cs", `password = $"{dbPassword}"`).length, 0);
+  // 2) a shell/env var path with a SCREAMING_SNAKE segment is not high-entropy.
+  assert.equal(
+    ruleIds("setup.sh", `  python -m pip install -r "$BACKEND_DIR/requirements.txt"`).includes("high-entropy-string"),
+    false
+  );
+  assert.equal(entropyCandidates("BACKEND_DIR/requirements").length, 2);
+  // But real hardcoded secrets are still caught.
+  assert.ok(ruleIds("a.py", 'password = "MyR3alHardcodedValue"').includes("generic-secret-assignment"));
+  assert.ok(ruleIds("a.ts", `const k = "${AWS_SECRET_KEY}"`).includes("high-entropy-string"));
 });
 
 test("inline gforge:allow suppresses a line", () => {


### PR DESCRIPTION
Fixes #19.

Two false positives reported by @psspl-shrey, both reproduced and root-caused, both fixed with regression tests. 75/75 tests pass.

## 1. `generic-secret-assignment` on Python f-strings

`headers = {"Authorization": f"Bearer {token}"}` was flagged. The value `f"Bearer {token}"` was treated as *unquoted* (the `f` prefix hid the quote), so it was split on the first whitespace to `f"Bearer` **before** the interpolation check ran — the `{token}` was never seen.

**Fix:** strip a language string-prefix (`f`/`r`/`b`/`u` and combinations) before quote detection, and recognize single-brace `{ident}` interpolation (Python f-strings, C#) in addition to `${...}` / `{{...}}` / `#{...}` / `%(...)s` / `<%...%>`.

## 2. `high-entropy-string` on SCREAMING_SNAKE paths

`pip install -r "$BACKEND_DIR/requirements.txt"` was flagged. `BACKEND_DIR/requirements` scores **4.2202** (threshold 4.2), and the per-segment path tokenizer's whole-token lowercase-ratio gate (needs ≥0.55) saw only **0.5455** because the all-caps `BACKEND_DIR` segment drags it down — so the token was scored whole instead of per-segment.

**Fix:** replace the whole-token lowercase gate with a per-segment "name" check — a segment is a name if it's short (`src`, `api`, `v2`), SCREAMING_SNAKE_CASE (`BACKEND_DIR`), or vowel-rich like a real word (~40% vowels). Random base64 segments are long, mixed-case, and ~19% vowels, so they fail every branch.

## Safety

The path-splitting change is the risk (splitting a base64 secret containing `/` could hide it). Monte-Carlo over random base64(+/) tokens shows detection retention of **98.6% (len 30) / 99.6% (len 40) / 99.9% (len 50)** — on par with the prior gate. All PR #16 path tests still pass (one assertion updated: an *all-caps* path now decomposes per-segment, which is correct — no secret format is all-uppercase *and* contains `/`).

Broad real-code sanity check (all pass, real secrets still caught):
- `f"Bearer {token}"`, `logger.info(f"user {user_id} ...")`
- TS import paths, shell/Make `$BACKEND_DIR/...`, k8s `.../PROJECT_NAMESPACE/...`
- still flags `password = "hunter2RealValue"` and high-entropy `API_KEY=...`