### PR TITLE
fix(meta): point repository URLs at canonical owner slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ platform include:
 ## Contributing
 
 Issues and pull requests are welcome at the
-[GitHub repository](https://github.com/psspl-gaurang-joshi/gforge). Please run
+[GitHub repository](https://github.com/psspl-gaurang/gforge). Please run
 `npm test` before submitting, keep changes focused, and preserve the Apache-2.0
 license header and `NOTICE`.
 

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
     "global-hooks"
   ],
   "license": "Apache-2.0",
-  "author": "Gaurang Joshi (https://github.com/psspl-gaurang-joshi)",
+  "author": "Gaurang Joshi (https://github.com/psspl-gaurang)",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/psspl-gaurang-joshi/gforge.git"
+    "url": "git+https://github.com/psspl-gaurang/gforge.git"
   },
   "bugs": {
-    "url": "https://github.com/psspl-gaurang-joshi/gforge/issues"
+    "url": "https://github.com/psspl-gaurang/gforge/issues"
   },
-  "homepage": "https://github.com/psspl-gaurang-joshi/gforge#readme",
+  "homepage": "https://github.com/psspl-gaurang/gforge#readme",
   "bin": {
     "gforge": "bin/gforge.js"
   },


### PR DESCRIPTION
## Summary
- GitHub's owner is `psspl-gaurang`, but `package.json`'s `repository`/`homepage`/`bugs` fields and one README link still pointed at the old, redirected `psspl-gaurang-joshi` slug.
- Updated all of them to the canonical URL so npm's generated "Repository" link and the README's Contributing link resolve directly instead of relying on GitHub's redirect.
- Also set the repo's homepage (About sidebar) to https://www.npmjs.com/package/gforge so the published npm package is discoverable from the GitHub repo page.

## Test plan
- [x] `npm test` — 75/75 passing
- [x] `npm pack --dry-run` sanity check not needed (no files/exports changed)