### PR TITLE
fix(scanner): stop the generic rule extracting bogus values from log …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gforge",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A git firewall: a global pre-commit hook that blocks commits containing secrets (passwords, keys, tokens, .env files) across macOS, Linux, and Windows.",
   "keywords": [
     "git",

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -59,8 +59,61 @@ export const PROVIDER_RULES = [
 export const GENERIC_SECRET_RULE_ID = "generic-secret-assignment";
 const GENERIC_SECRET_DESCRIPTION = "hardcoded value assigned to a credential keyword";
 const GENERIC_KEYWORD_RE = /(?:^|[^A-Za-z0-9])(?:passwd|password|passphrase|pwd|pass|secret(?:[_-]?key)?|token|access[_-]?token|auth(?:[_-]?token)?|authorization|bearer|api[_-]?key|apikey|access[_-]?key|client[_-]?secret|private[_-]?key|encryption[_-]?key|signing[_-]?key|session[_-]?key|connection[_-]?string|conn[_-]?str|credentials?)["'`]?\s*[:=]\s*(\S.*)$/i;
-const VALUE_PLACEHOLDER_RE = /^(your|my|the|changeme|change[_-]?me|example|placeholder|redacted|dummy|sample|test|none|null|nil|undefined|true|false|xxx+|x{3,}|\*+|todo|tbd|password|passwd|secret|token|value|string)$/i;
+const VALUE_PLACEHOLDER_RE = /^(your|my|the|changeme|change[_-]?me|example|placeholder|redacted|dummy|sample|test|none|null|nil|undefined|true|false|xxx+|x{3,}|\*+|todo|tbd|password|passwd|secret|token|value|string|auth|authorization|key|apikey|api[_-]?key|credentials?)$/i;
 const VALUE_REFERENCE_ROOT_RE = /^(process|import|globalThis|window|os|System|Deno|ENV|env|config|configService|vault|secret|secrets|settings)$/i;
+// An Authorization value names its scheme before the credential ("Bearer <jwt>",
+// "Basic <base64>"). The scheme is a label, so judge what FOLLOWS it: a real
+// token after it must still flag, a bare scheme name must not (issue #23).
+const AUTH_SCHEME_PREFIX_RE = /^(?:bearer|basic|digest|negotiate|oauth|jwt|token|apikey|api[_-]?key)\b[\s:]*/i;
+// Expression punctuation cannot begin a credential literal. Catches the wreckage
+// left when a keyword sat inside a string literal and the capture therefore
+// starts at a stray quote (issue #23).
+const VALUE_FRAGMENT_START_RE = /^[,;:)\]}?]/;
+
+// A route/path template ("changepassword/:uuid") is a placeholder, not a value.
+// Every segment must be a plain lowercase word or a :param — one mixed-case or
+// random-looking segment means the path carries a real token and stays eligible,
+// so a secret appended to a route prefix is still caught (issue #23).
+const ROUTE_SEGMENT_RE = /^[a-z][a-z0-9-]*$/;
+const ROUTE_SEGMENT_MAX_LENGTH = 20; // real route words; secrets run longer
+// Below IDENTIFIER_MIN_VOWEL_RATIO because compound route words are vowel-poor
+// ("changepassword" is 0.286), while random lowercase letters sit near 0.19.
+const ROUTE_MIN_VOWEL_RATIO = 0.25;
+
+// A route segment is a WORD, not a blob. Lowercase is not enough on its own: hex
+// beginning a-f ("a3f9b2c8…") and an all-lowercase token are lowercase too, and
+// entropy cannot separate them (24 random lowercase letters score under the 4.2
+// gate). Length, digit density, and vowel ratio can — so a secret cannot ride
+// into the allowlist behind a route prefix.
+function looksLikeRouteSegment(segment) {
+  const word = segment.replace(/^:/, "");
+  if (!ROUTE_SEGMENT_RE.test(word)) return false;
+  if (word.length > ROUTE_SEGMENT_MAX_LENGTH) return false;
+  const digits = (word.match(/[0-9]/g) || []).length;
+  if (digits > PATH_SEGMENT_MAX_DIGITS && digits / word.length > PATH_SEGMENT_MAX_DIGIT_RATIO) return false;
+  if (word.length < NAME_SEGMENT_MIN_CHECK_LENGTH) return true; // api, v1, uuid
+  const letters = word.replace(/[^a-z]/g, "");
+  return letters.length > 0 && ratioOf(letters, /[aeiou]/g) >= ROUTE_MIN_VOWEL_RATIO;
+}
+function looksLikeRouteTemplate(value) {
+  if (!/[/]:[A-Za-z_]/.test(value)) return false;
+  return value.split("/").filter(Boolean).every(looksLikeRouteSegment);
+}
+
+// A constant whose value merely restates its own name is a label, not a
+// credential: CALL_HISTORY_..._SESSION_KEY = "call-history-skip-default-filters".
+// Only the "value is spelled out inside the key" direction counts — a random
+// secret cannot appear inside the identifier that names it, whereas the reverse
+// would suppress a real one (AUTH = "s3cr3tAuthValue123") (issue #23).
+const KEY_IDENTIFIER_RE = /([A-Za-z_][\w.$-]*)\s*["'`]?\s*[:=]\s*$/;
+function echoesItsKey(value, keyContext) {
+  if (!keyContext) return false;
+  const key = keyContext.match(KEY_IDENTIFIER_RE);
+  if (!key) return false;
+  const flatten = (text) => text.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const flatValue = flatten(value);
+  return flatValue.length >= 4 && flatten(key[1]).includes(flatValue);
+}
 
 // Decide whether the value assigned to a credential keyword is a hardcoded
 // literal (flag) rather than a reference/placeholder (ignore).
@@ -73,17 +126,30 @@ export function looksLikeHardcodedSecret(rawValue, options = {}) {
   const quoted = quote === '"' || quote === "'" || quote === "`";
   if (quoted) {
     const end = value.indexOf(quote, 1);
-    value = end === -1 ? value.slice(1) : value.slice(1, end);
-  } else {
-    value = value.split(/[\s,;)}\]]/)[0];
+    // No closing quote: this quote CLOSES a string the keyword sat inside, so the
+    // ':' was prose, not an assignment operator. A real `password = "…` without a
+    // closing quote is a syntax error, whereas
+    // `console.error('failed to clear auth:', err)` is everyday code (issue #23).
+    if (end === -1) return false;
+    value = value.slice(1, end);
+  }
+  // Drop the scheme label so the credential itself is judged.
+  value = value.replace(AUTH_SCHEME_PREFIX_RE, "").trim();
+  if (!quoted) {
+    // Unquoted: the value ends at the first separator. A trailing quote closes the
+    // string this value was embedded in (-H "Authorization: Bearer TOKEN").
+    value = value.split(/[\s,;)}\]]/)[0].replace(/["'`]+$/, "");
   }
   value = value.trim();
 
   if (value.length < 4) return false;
+  // An expression fragment, not a literal.
+  if (VALUE_FRAGMENT_START_RE.test(value)) return false;
   // Interpolations / template placeholders are references, not literals:
   // ${...}, {{...}}, %(...)s, <%...%>, #{...}, and single-brace {ident} used by
   // Python f-strings and C# interpolated strings (e.g. `Bearer {token}`).
   if (/\$\{|\{\{|%\(|<%|#\{|\{[A-Za-z_][\w.]*\}/.test(value)) return false;
+  if (looksLikeRouteTemplate(value)) return false;
   if (!quoted) {
     // Unquoted expressions: shell vars, member access, function calls, env lookups.
     if (value.startsWith("$")) return false;
@@ -97,6 +163,7 @@ export function looksLikeHardcodedSecret(rawValue, options = {}) {
   // Env-name-like placeholders (DB_PASSWORD) and common dummy values.
   if (/^[A-Z][A-Z0-9_]{2,}$/.test(value)) return false;
   if (VALUE_PLACEHOLDER_RE.test(value)) return false;
+  if (echoesItsKey(value, options.keyContext)) return false;
   if (/^<.*>$/.test(value) || value === "...") return false;
 
   return true;
@@ -360,7 +427,10 @@ export function scanText(filePath, content, options = {}) {
 
     if (includeGeneric) {
       const match = line.match(GENERIC_KEYWORD_RE);
-      if (match && looksLikeHardcodedSecret(match[1], { codeFile })) {
+      // Everything left of the value: the capture runs to end of line, so the
+      // remainder names the key the value was assigned to.
+      const keyContext = match ? line.slice(0, line.length - match[1].length) : "";
+      if (match && looksLikeHardcodedSecret(match[1], { codeFile, keyContext })) {
         findings.push({
           file: filePath,
           line: lineNumber,

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  GENERIC_SECRET_RULE_ID,
   decodeBlob,
   entropyCandidates,
   formatReport,
@@ -208,6 +209,65 @@ test("issue #19: f-string interpolation and SCREAMING_SNAKE path segments are no
   // But real hardcoded secrets are still caught.
   assert.ok(ruleIds("a.py", 'password = "MyR3alHardcodedValue"').includes("generic-secret-assignment"));
   assert.ok(ruleIds("a.ts", `const k = "${AWS_SECRET_KEY}"`).includes("high-entropy-string"));
+});
+
+test("issue #23: the generic rule does not mine bogus values out of log statements", () => {
+  // The keyword and its ':' sit INSIDE a string literal, so the quote that follows
+  // is that string's CLOSING quote -- previously mistaken for the start of a value.
+  assert.equal(ruleIds("sw.ts", "console.error('[AuthManager] Failed to clear auth:', error);").length, 0);
+  assert.equal(ruleIds("sw.ts", "console.error('[SERVICE_WORKER] Failed to clear token:', error);").length, 0);
+  // Here the stray quote pairs with a later, unrelated literal, yielding the
+  // expression fragment ", authState.token ?".
+  assert.equal(
+    ruleIds("conn.ts", "console.log('[Connection] Using auth token:', authState.token ? 'Present' : 'Missing');").length,
+    0
+  );
+  assert.equal(ruleIds("log.ts", "logger.info('auth token: ' + t)").length, 0);
+});
+
+test("issue #23: labels, auth schemes, and route templates are not credentials", () => {
+  // A value that is just the name of the thing is a label.
+  assert.equal(ruleIds("routes.ts", 'export const AUTH = "auth";').length, 0);
+  assert.equal(ruleIds("consts.ts", 'BEARER: "Bearer"').length, 0);
+  // An Authorization value names its scheme first; judge what follows it.
+  assert.equal(ruleIds("README.md", '-H "Authorization: Bearer YOUR_JWT_TOKEN"').length, 0);
+  // A route template is a placeholder, not a value.
+  assert.equal(ruleIds("routes.ts", 'export const CHANGE_PASSWORD = "changepassword/:uuid";').length, 0);
+  // A constant whose value just restates its own name is a label.
+  assert.equal(
+    ruleIds("keys.ts", 'export const CALL_HISTORY_SKIP_DEFAULT_FILTERS_SESSION_KEY = "call-history-skip-default-filters";').length,
+    0
+  );
+});
+
+test("issue #23: the same shapes carrying a REAL credential are still blocked", () => {
+  // The scheme is stripped, not trusted: a real token after it must still flag.
+  assert.ok(ruleIds("a.txt", "Authorization: Bearer abcdef2345token").includes(GENERIC_SECRET_RULE_ID));
+  assert.ok(ruleIds("a.sh", 'curl -H "Authorization: Basic YWRtaW46czNjcjN0"').includes(GENERIC_SECRET_RULE_ID));
+  assert.ok(ruleIds("c.ts", 'BEARER: "Bearer aX9kQm2pLw8vRt4z"').includes(GENERIC_SECRET_RULE_ID));
+  // A label-shaped constant name with a real value is still a hardcoded secret.
+  assert.ok(ruleIds("c.ts", 'const AUTH = "s3cr3tAuthValue123";').includes(GENERIC_SECRET_RULE_ID));
+  // A route prefix does not launder a token appended to it: one random-looking
+  // segment means the path is not a template. Lowercase shapes matter most here --
+  // hex beginning a-f and all-lowercase tokens are lowercase like a route word,
+  // and entropy alone cannot separate them.
+  assert.ok(
+    ruleIds("r.ts", 'export const TOKEN = "changepassword/:uuid/aX9kQm2pLw8vRt4zNc";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  assert.ok(
+    ruleIds("r.ts", 'const token = "changepassword/:uuid/a3f9b2c8d1e4f7a2b9c3d8e1f4a7b2c9";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  assert.ok(
+    ruleIds("r.ts", 'const token = "changepassword/:uuid/qwrtypsdfghjklzxcvbnmqwe";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  // A descriptive key name does not launder a real value: the key-echo rule only
+  // fires when the value is spelled out INSIDE the key, never the reverse.
+  assert.ok(
+    ruleIds("keys.ts", 'export const CALL_HISTORY_SESSION_KEY = "aX9kQm2pLw8vRt4zNc";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  // A quoted value is still read normally when the quotes are balanced.
+  assert.ok(ruleIds("a.sh", `PASSWORD="it's-a-s3cr3t"`).includes(GENERIC_SECRET_RULE_ID));
+  assert.ok(ruleIds("a.js", `const token = "abc123def456" // user's key`).includes(GENERIC_SECRET_RULE_ID));
 });
 
 test("inline gforge:allow suppresses a line", () => {


### PR DESCRIPTION
…statements (#23)

The generic secret-assignment rule matched a credential keyword followed by an optional quote and ':'/'=' without checking that the separator was actually an assignment operator. All 11 reported false positives trace to five distinct defects in looksLikeHardcodedSecret:

1. Unterminated quote. In console.error('[AuthManager] Failed to clear auth:', error) the keyword and its ':' sit INSIDE a string literal, so the quote that follows CLOSES that literal. It was consumed as an OPENING quote and the leftovers ", error);" became the "value". A genuine password = "... with no closing quote is a syntax error, so an unpaired quote now rejects. This covers all six reported log statements.

2. Cross-literal pairing. In console.log('[Connection] Using auth token:', authState.token ? 'Present' : 'Missing') the stray quote paired with a later, unrelated literal, yielding the expression fragment ", authState.token ?". Expression punctuation cannot begin a credential literal.

3. The scheme label taken for the credential. -H "Authorization: Bearer YOUR_JWT_TOKEN" extracted "Bearer" and never examined the placeholder behind it. The scheme is now stripped so the credential itself is judged: Bearer abcdef2345token still flags, a bare BEARER: "Bearer" does not.

4. Constants that restate their own name. CALL_HISTORY_SKIP_DEFAULT_FILTERS_ SESSION_KEY = "call-history-skip-default-filters" and AUTH = "auth" are labels. Only the "value spelled out inside the key" direction counts: a random secret cannot appear inside the identifier naming it, whereas the reverse would suppress AUTH = "s3cr3tAuthValue123".

5. Route templates. CHANGE_PASSWORD = "changepassword/:uuid" is a placeholder. Segments are word-tested (length, digit density, vowel ratio) rather than entropy-tested: 24 random lowercase letters score under the 4.2-bit gate and hex beginning a-f is all-lowercase, so an entropy test let a token ride in behind a route prefix. Regression tests cover both lowercase shapes.

Verification:
- All 11 examples from the issue, extracted from the body rather than transcribed: 0 false positives.
- End-to-end through a real repo with real staged files: commit allowed, while a control commit carrying a genuine secret is still blocked.
- Detection retention measured against the previous engine over 32,000 random secrets (8 shapes x 10 syntactic contexts): 100.00% before, 100.00% after.

Known limit: an all-lowercase, word-like secret of 20 characters or fewer appended to a route template is not detected; tightening further would flag ordinary constants such as "reset-password/:token/confirm".

Fixes #23. Bump 0.3.6.