### PR TITLE
fix(scanner): skip the heuristic rules in i18n, docs and build output…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,25 @@ value**. Detection runs several layers in order:
 
 Detection is best-effort and complements — not replaces — good secret hygiene.
 
+### Paths the heuristic layers skip
+
+A credential keyword followed by a colon is the *normal* shape of a translation
+entry (`"Password": "Passwort"`) and of a documentation example, so layers 3 and 4
+— the two heuristic ones — are skipped by default in:
+
+| Kind | Matched by |
+| --- | --- |
+| Translations / i18n | a `i18n`, `l10n`, `intl`, `translation(s)`, `locale(s)`, `lang(s)` directory |
+| Documentation | a `doc(s)`, `document(s)`, `documentation` directory, or a `.md`/`.mdx`/`.rst`/`.adoc` file |
+| Generated output | a `dist`, `build`, `out`, `coverage`, `vendor`, `node_modules`, `target`, `obj`, `.next`, `.nuxt` … directory |
+| Lockfiles & bundles | `package-lock.json`, `yarn.lock`, `go.sum`, … and `*.min.js`, `*.min.css`, `*.map` |
+
+**Layers 1, 2 and 5 always run, everywhere.** A real AWS, Stripe, GitHub, or
+Google credential, a private key, a `.env` file, or a value copied out of your
+`.env` is still blocked inside `dist/`, a README, or a translation catalogue —
+only the noisy keyword and entropy heuristics are quietened. Set
+`GFORGE_NO_DEFAULT_EXCLUDES=1` to scan every path with every layer.
+
 ## Managing false positives
 
 Maximum coverage occasionally flags something safe. Three escape hatches:
@@ -159,6 +178,7 @@ file to manage.
 | `GFORGE_NO_SELF_UPDATE=1` | Skip the npm self-upgrade in `install`/`update` (CI / air-gapped). |
 | `GFORGE_SKIP_POSTINSTALL=1` | Skip automatic hook setup during `npm install`. |
 | `GFORGE_NODE=/path/to/node` | Pin the Node.js runtime the hook uses. |
+| `GFORGE_NO_DEFAULT_EXCLUDES=1` | Run the heuristic layers on every path, including translations, docs, and build output. |
 
 If a repository or the system already defines its own `core.hooksPath` (e.g. Husky
 or lefthook), GForge does not override it; run `gforge install` to have GForge take

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gforge",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A git firewall: a global pre-commit hook that blocks commits containing secrets (passwords, keys, tokens, .env files) across macOS, Linux, and Windows.",
   "keywords": [
     "git",

--- a/src/cli.js
+++ b/src/cli.js
@@ -183,9 +183,10 @@ function helpText(stream) {
     row("help", "Display this help"),
     "",
     header("Environment:"),
-    row("GFORGE_AUTO_UPDATE=0", "Disable automatic background upgrades (on by default)", 26),
-    row("GFORGE_NO_SELF_UPDATE=1", "Skip the npm self-upgrade in install / update", 26),
-    row("GFORGE_SKIP_POSTINSTALL=1", "Skip auto-setup during npm install", 26),
+    row("GFORGE_AUTO_UPDATE=0", "Disable automatic background upgrades (on by default)", 30),
+    row("GFORGE_NO_SELF_UPDATE=1", "Skip the npm self-upgrade in install / update", 30),
+    row("GFORGE_SKIP_POSTINSTALL=1", "Skip auto-setup during npm install", 30),
+    row("GFORGE_NO_DEFAULT_EXCLUDES=1", "Scan translations, docs and build output too", 30),
     ""
   ].join("\n");
 }

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -1,3 +1,52 @@
+
+// ---------------------------------------------------------------------------
+// Content that is not hand-written application code: translation catalogues,
+// documentation, generated build output, and lockfiles. A credential keyword
+// followed by a colon is the NORMAL shape of a translation entry
+// ("Password": "Passwort") and of a docs example, so the two heuristic rules —
+// generic keyword assignment and entropy — produce nothing but noise there.
+//
+// Only those two are suppressed. Provider rules, the secret-file rules, and the
+// .env cross-reference still run on every file, so a real AWS/Stripe/GitHub
+// credential committed into dist/ or a README is still blocked (issue #24).
+// ---------------------------------------------------------------------------
+const I18N_DIRECTORIES = new Set([
+  "i18n", "l10n", "intl", "translation", "translations", "locale", "locales", "lang", "langs"
+]);
+const DOC_DIRECTORIES = new Set(["doc", "docs", "document", "documents", "documentation"]);
+// Conventional build/vendor output. Deliberately excludes "bin" and "lib", which
+// commonly hold hand-written source.
+const GENERATED_DIRECTORIES = new Set([
+  "dist", "build", "out", "output", "coverage", "vendor", "node_modules",
+  "bower_components", "target", "obj", "__pycache__", ".next", ".nuxt", ".output",
+  ".svelte-kit", ".angular", ".parcel-cache", ".turbo"
+]);
+// Documentation formats. `.txt` is deliberately absent — it is a common place for
+// real config, and the suite relies on config.txt still being scanned.
+const DOC_EXTENSIONS = new Set(["md", "mdx", "markdown", "rst", "adoc", "asciidoc"]);
+
+export function isHeuristicExemptPath(filePath, env = process.env) {
+  // Escape hatch: scan everything, exclusions off. A security tool should never
+  // have a blind spot that cannot be switched back on.
+  if (env && env.GFORGE_NO_DEFAULT_EXCLUDES) return null;
+
+  const normalized = String(filePath).replace(/\\/g, "/").toLowerCase();
+  const segments = normalized.split("/").filter(Boolean);
+  const name = segments[segments.length - 1] ?? "";
+  const directories = segments.slice(0, -1);
+
+  if (directories.some((segment) => I18N_DIRECTORIES.has(segment))) return "i18n";
+  if (directories.some((segment) => DOC_DIRECTORIES.has(segment))) return "docs";
+  if (directories.some((segment) => GENERATED_DIRECTORIES.has(segment))) return "generated";
+
+  const dot = name.lastIndexOf(".");
+  const extension = dot > 0 ? name.slice(dot + 1) : "";
+  if (DOC_EXTENSIONS.has(extension)) return "docs";
+  if (LOCKFILE_NAMES.has(name)) return "generated";
+  if (name.endsWith(".min.js") || name.endsWith(".min.css") || name.endsWith(".map")) return "generated";
+
+  return null;
+}
 // GForge secret-scanning engine.
 //
 // This module is intentionally self-contained: it imports only Node built-ins,
@@ -61,6 +110,11 @@ const GENERIC_SECRET_DESCRIPTION = "hardcoded value assigned to a credential key
 const GENERIC_KEYWORD_RE = /(?:^|[^A-Za-z0-9])(?:passwd|password|passphrase|pwd|pass|secret(?:[_-]?key)?|token|access[_-]?token|auth(?:[_-]?token)?|authorization|bearer|api[_-]?key|apikey|access[_-]?key|client[_-]?secret|private[_-]?key|encryption[_-]?key|signing[_-]?key|session[_-]?key|connection[_-]?string|conn[_-]?str|credentials?)["'`]?\s*[:=]\s*(\S.*)$/i;
 const VALUE_PLACEHOLDER_RE = /^(your|my|the|changeme|change[_-]?me|example|placeholder|redacted|dummy|sample|test|none|null|nil|undefined|true|false|xxx+|x{3,}|\*+|todo|tbd|password|passwd|secret|token|value|string|auth|authorization|key|apikey|api[_-]?key|credentials?)$/i;
 const VALUE_REFERENCE_ROOT_RE = /^(process|import|globalThis|window|os|System|Deno|ENV|env|config|configService|vault|secret|secrets|settings)$/i;
+// A letter that is not Latin script. Translated UI labels are written in the
+// target language ("Password": "पासवर्ड"), and no credential is ever spelled in
+// Devanagari, CJK, Cyrillic, Arabic, … — so this is a safe, unambiguous signal
+// for translation catalogues that sit outside a recognised i18n path (issue #24).
+const NON_LATIN_LETTER_RE = /[^\P{L}\p{Script=Latin}]/u;
 // An Authorization value names its scheme before the credential ("Bearer <jwt>",
 // "Basic <base64>"). The scheme is a label, so judge what FOLLOWS it: a real
 // token after it must still flag, a bare scheme name must not (issue #23).
@@ -160,6 +214,11 @@ export function looksLikeHardcodedSecret(rawValue, options = {}) {
     // bare word IS the literal value, so only exempt this for code files.
     if (options.codeFile && /^[A-Za-z_$][\w$]*$/.test(value)) return false;
   }
+  // A translated label, not a credential. Narrow on purpose: the value must be
+  // PURE non-Latin text (no ASCII letters or digits) and must sit in a data file,
+  // so a human-chosen password in application code — password = "пароль123", or
+  // even bare "пароль" — is still flagged.
+  if (!options.codeFile && NON_LATIN_LETTER_RE.test(value) && !/[A-Za-z0-9]/.test(value)) return false;
   // Env-name-like placeholders (DB_PASSWORD) and common dummy values.
   if (/^[A-Z][A-Z0-9_]{2,}$/.test(value)) return false;
   if (VALUE_PLACEHOLDER_RE.test(value)) return false;
@@ -389,15 +448,12 @@ function isPathAllowlisted(filePath, allowlist) {
 export function scanText(filePath, content, options = {}) {
   const findings = [];
   const name = basename(filePath).toLowerCase();
-  const skipEntropy =
-    options.entropy === false ||
-    LOCKFILE_NAMES.has(name) ||
-    name.endsWith(".min.js") ||
-    name.endsWith(".min.css") ||
-    name.endsWith(".map") ||
-    looksBinary(content);
+  // Translation catalogues, docs, build output and lockfiles: suppress the two
+  // heuristic rules, never the high-confidence ones (issue #24).
+  const exemptReason = isHeuristicExemptPath(filePath);
+  const skipEntropy = options.entropy === false || Boolean(exemptReason) || looksBinary(content);
 
-  const includeGeneric = options.generic !== false;
+  const includeGeneric = options.generic !== false && !exemptReason;
   const codeFile = isCodeFile(filePath);
   // Twilio auth tokens are bare 32-hex strings (no prefix), indistinguishable
   // from an MD5 on their own. Only treat a 32-hex string as a token when the

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -6,6 +6,7 @@ import {
   decodeBlob,
   entropyCandidates,
   formatReport,
+  isHeuristicExemptPath,
   isEnvTemplate,
   matchFilenameRule,
   parseAllowlist,
@@ -193,6 +194,65 @@ test("entropyCandidates decomposes paths and leaves opaque tokens whole", () => 
     "COMPONENTS",
     "GLOBALFILTERSUMMARYTRIGGER"
   ]);
+});
+
+test("issue #24: translation catalogues, docs and build output skip the heuristic rules", () => {
+  // "Password": "Passwort" is the normal shape of a translation entry.
+  assert.equal(ruleIds("client/src/translations/hi/common.json", '  "Password": "पासवर्ड",').length, 0);
+  assert.equal(ruleIds("client/src/translations/hi/common.json", '  "clientSecret": "क्लाइंट सीक्रेट",').length, 0);
+  assert.equal(ruleIds("client/src/translations/en/common.json", '  "clientSecret": "Client Secret",').length, 0);
+  assert.equal(ruleIds("client/src/translations/de/common.json", '  "token": "Authentifizierungstoken",').length, 0);
+  assert.equal(ruleIds("client/src/translations/fr/common.json", `  "token": "Jeton d'authentification",`).length, 0);
+  assert.equal(ruleIds("server/src/i18n/en/responseMessage.json", '  "invalidPassword": "The password you entered is incorrect",').length, 0);
+  assert.equal(ruleIds("resources/lang/es/auth.php", "'password' => 'La contrasena es incorrecta',").length, 0);
+  // Docs and build output.
+  assert.equal(ruleIds("server/src/core/logger/README.md", "password: your-database-password").length, 0);
+  assert.equal(ruleIds("documents/features/auth.md", "| clientSecret | shhh-do-not-share-this |").length, 0);
+  assert.equal(ruleIds("client/dist/index.html", 'var token="anonymous-public-widget-token";').length, 0);
+  // The generic rule now has the skip list the entropy rule already had.
+  assert.equal(ruleIds("server/package-lock.json", '  "token": "abcd1234efgh5678",').length, 0);
+  assert.equal(ruleIds("a/b.min.js", 'var password="abcd1234efgh5678";').length, 0);
+});
+
+test("issue #24: exemptions are path-scoped and never disable the high-confidence rules", () => {
+  // Provider rules, which carry no false-positive risk, still fire everywhere.
+  for (const path of [
+    "client/dist/index.html",
+    "docs/setup.md",
+    "client/src/translations/hi/common.json",
+    "server/package-lock.json"
+  ]) {
+    assert.ok(ruleIds(path, "AKIAIOSFODNN7EXAMPLE").includes("aws-access-key-id"), path);
+    assert.ok(ruleIds(path, `k = "sk_live_${"a".repeat(24)}"`).includes("stripe-secret-key"), path);
+    assert.ok(ruleIds(path, "-----BEGIN RSA PRIVATE KEY-----").includes("private-key"), path);
+  }
+  // Lookalike directory names are ordinary source and stay fully scanned.
+  for (const path of [
+    "src/distributor/api.ts",
+    "src/building/service.ts",
+    "src/outbound/mailer.ts",
+    "src/language/parser.ts",
+    "server/src/i18nUtils.ts",
+    "config.txt"
+  ]) {
+    assert.ok(ruleIds(path, 'const password = "S3cr3tDbP4ssw0rd";').includes(GENERIC_SECRET_RULE_ID), path);
+  }
+  assert.equal(isHeuristicExemptPath("client/src/translations/hi/common.json"), "i18n");
+  assert.equal(isHeuristicExemptPath("README.md"), "docs");
+  assert.equal(isHeuristicExemptPath("client/dist/index.html"), "generated");
+  assert.equal(isHeuristicExemptPath("src/config/db.js"), null);
+  // Windows separators classify the same way.
+  assert.equal(isHeuristicExemptPath("client\\dist\\index.html"), "generated");
+  // The exclusions can be switched off entirely.
+  assert.equal(isHeuristicExemptPath("client/dist/index.html", { GFORGE_NO_DEFAULT_EXCLUDES: "1" }), null);
+});
+
+test("issue #24: the non-Latin guard does not hide a real credential", () => {
+  // A translated label in a data file is not a secret...
+  assert.equal(ruleIds("client/messages/hi.json", '"Password": "पासवर्ड"').length, 0);
+  // ...but a human-chosen password in application code still is, script regardless.
+  assert.ok(ruleIds("app.js", 'const password = "пароль123";').includes(GENERIC_SECRET_RULE_ID));
+  assert.ok(ruleIds("app.js", 'const password = "пароль";').includes(GENERIC_SECRET_RULE_ID));
 });
 
 test("issue #19: f-string interpolation and SCREAMING_SNAKE path segments are not secrets", () => {


### PR DESCRIPTION
… (#24)

A translation entry has the same shape as a hardcoded credential: a keyword, a colon, and a quoted literal. "Password": "Passwort" matched the generic rule exactly, so every localisation of password/token/clientSecret was reported as a leaked secret and any translation update blocked the commit in every language. The generic rule had no skip list at all, and the entropy rule's list covered only lockfiles, minified files and binaries.

Adds a path classifier that suppresses the two HEURISTIC layers - generic keyword assignment and entropy - for:

  i18n        i18n, l10n, intl, translation(s), locale(s), lang(s) directories
  docs        doc(s), document(s), documentation dirs; .md/.mdx/.rst/.adoc files
  generated   dist, build, out, coverage, vendor, node_modules, target, obj,
              .next, .nuxt, ... directories
  lockfiles   package-lock.json, yarn.lock, go.sum, ...; *.min.js, *.min.css, *.map

Only those two layers are affected. Provider rules, the secret-file rules and the .env cross-reference still run on every path, so a real AWS/Stripe/GitHub credential, a private key, a committed .env, or a value copied out of .env is still blocked inside dist/, a README or a translation catalogue.

Also adds a deliberately narrow guard for translation files that sit outside a recognised i18n directory: a value is treated as a translated label only when it is pure non-Latin text and lives in a data file, so a human-chosen password in application code (password = "<cyrillic>123", or even a bare word) still flags.

GFORGE_NO_DEFAULT_EXCLUDES=1 turns the exclusions off entirely - a security tool should not carry a blind spot that cannot be switched back on. Documented in the README and in `gforge --help`.

Verification:
- Fixtures built from the issue body: 20 findings before, 0 after; controls (a hardcoded db password, a Stripe key) still fire.
- A real package-lock.json generated with npm: "@octokit/auth-token": "^4.0.0" tripped the generic rule before, 0 findings after.
- Detection retention measured against the previous engine over 32,000 random secrets in non-exempt paths (8 shapes x 10 syntactic contexts): 100% -> 100%.
- Installed as a real pre-commit hook driving real commits: translations, docs and dist commit through; a hardcoded password is blocked, an AWS key inside dist/ is blocked, the secret value is never printed, gforge:allow still works.
- Issue #23 regression set re-checked on the merged tree: still 0/11.

Known limit: inside an exempt path, a secret with no recognisable vendor format is no longer caught by the heuristic layers. That trade is the substance of this issue; GFORGE_NO_DEFAULT_EXCLUDES=1 restores full scanning.

Fixes #24. Bump 0.3.7.