### PR TITLE
Add CI workflow to gate merges on the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20.x", "22.x"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test
+      - run: npm run package:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Do not expand it into:
 
 ## Working Rules
 
+- Commit as the repository owner's configured git user only. Never add an AI
+  tool (e.g. Claude) as a co-author or include a `Co-Authored-By` trailer.
 - Keep docs and code token-friendly.
 - Prefer updating the existing root docs over adding new docs.
 - Do not invent commands, APIs, or scope.


### PR DESCRIPTION
Runs npm test (and a package:check sanity build) on every push to master and every pull request, across Node 20.x and 22.x. Nothing currently blocks a PR with a failing test from being merged; this closes that gap.

Also documents in AGENTS.md that agents must commit as the repo owner's own git user only, with no Co-Authored-By trailer.

Fixes #30