### PR TITLE
Add minimum git version check for core.hooksPath support

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -22,6 +22,41 @@ import {
   resolveStatePath
 } from "./hooks.js";
 
+// core.hooksPath was added in git 2.9. An older git accepts and stores the
+// config key unconditionally (git happily persists config keys it doesn't act
+// on) but never consults it when running hooks - install/verify would both
+// report success while the scanner silently never runs on any commit.
+const MIN_GIT_VERSION_FOR_HOOKS_PATH = [2, 9, 0];
+
+// Tolerates platform-specific suffixes on `git --version` output (e.g.
+// "2.39.2 (Apple Git-143)" on macOS, "2.34.1.windows.1" on Windows) by only
+// reading the leading numeric run.
+function parseGitVersionParts(version) {
+  const match = String(version ?? "").match(/^(\d+)\.(\d+)(?:\.(\d+))?/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+}
+
+// Unparseable versions fail closed (treated as not meeting the minimum)
+// rather than silently assuming support.
+function meetsMinimumGitVersion(version, minimum) {
+  const parts = parseGitVersionParts(version);
+  if (!parts) return false;
+  for (let i = 0; i < minimum.length; i += 1) {
+    const actual = parts[i] ?? 0;
+    const required = minimum[i];
+    if (actual !== required) return actual > required;
+  }
+  return true;
+}
+
+function describeGitTooOld(version) {
+  return (
+    `Git ${version} does not support core.hooksPath (added in git 2.9) - ` +
+    "hooks would silently never run even though config reports success. Upgrade git."
+  );
+}
+
 export async function installManagedHooks(options = {}) {
   const environment = options.environment ?? (await detectEnvironment(options));
   const execFileFn = options.execFile;
@@ -166,6 +201,17 @@ export async function verifyManagedHooks(options = {}) {
   const hooksDirectory = resolveHooksDirectory(environment.home.path);
   const configuredHooksPath = await safeGetGlobalHooksPath(execFileFn);
 
+  if (environment.git.available && !meetsMinimumGitVersion(environment.git.version, MIN_GIT_VERSION_FOR_HOOKS_PATH)) {
+    // Surfaced even when hooks-path below reports PASS: git accepts and
+    // stores core.hooksPath unconditionally on older versions, but never
+    // consults it, so a passing config check alone does not mean hooks run.
+    checks.push({
+      status: "FAIL",
+      label: "git-version",
+      detail: describeGitTooOld(environment.git.version)
+    });
+  }
+
   checks.push({
     status: configuredHooksPath === hooksDirectory ? "PASS" : "FAIL",
     label: "hooks-path",
@@ -262,6 +308,8 @@ function validateInstallPreflight(environment) {
 
   if (!environment.git.available) {
     messages.push("Git is required but was not found.");
+  } else if (!meetsMinimumGitVersion(environment.git.version, MIN_GIT_VERSION_FOR_HOOKS_PATH)) {
+    messages.push(describeGitTooOld(environment.git.version));
   }
 
   return messages;

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -385,6 +385,62 @@ test("uninstall still removes files when the global gitconfig cannot be read", a
   await assert.rejects(stat(resolveStatePath(homePath)), { code: "ENOENT" });
 });
 
+test("refuses to install on a git older than 2.9 (no core.hooksPath support)", async () => {
+  const homePath = await createTempHome();
+  const git = createGitConfigMock();
+  const environment = { ...createEnvironment(homePath), git: { available: true, version: "2.8.4", rawVersion: "git version 2.8.4" } };
+
+  const result = await installManagedHooks({ environment, execFile: git.execFile });
+
+  assert.equal(result.ok, false);
+  assert.match(result.messages.join("\n"), /does not support core\.hooksPath/);
+  // Must fail closed: nothing should have been configured against this git.
+  assert.equal(git.hooksPath(), null);
+});
+
+test("installs fine on exactly the minimum supported git version (2.9.0)", async () => {
+  const homePath = await createTempHome();
+  const git = createGitConfigMock();
+  const environment = { ...createEnvironment(homePath), git: { available: true, version: "2.9.0", rawVersion: "git version 2.9.0" } };
+
+  const result = await installManagedHooks({ environment, execFile: git.execFile });
+
+  assert.equal(result.ok, true);
+});
+
+test("tolerates platform-specific suffixes on the git version string (e.g. Apple Git builds)", async () => {
+  const homePath = await createTempHome();
+  const git = createGitConfigMock();
+  const environment = {
+    ...createEnvironment(homePath),
+    git: { available: true, version: "2.39.2 (Apple Git-143)", rawVersion: "git version 2.39.2 (Apple Git-143)" }
+  };
+
+  const result = await installManagedHooks({ environment, execFile: git.execFile });
+
+  assert.equal(result.ok, true);
+});
+
+test("verify fails the git-version check on an old git even if hooksPath happens to be configured", async () => {
+  const homePath = await createTempHome();
+  const hooksDirectory = resolveHooksDirectory(homePath);
+  // Simulates the exact silent-failure scenario from the bug report: an old
+  // git that accepted and stored core.hooksPath without ever consulting it.
+  const git = createGitConfigMock(hooksDirectory);
+  const environment = { ...createEnvironment(homePath), git: { available: true, version: "2.7.0", rawVersion: "git version 2.7.0" } };
+
+  const report = await verifyManagedHooks({ environment, execFile: git.execFile });
+
+  const versionCheck = report.checks.find((check) => check.label === "git-version");
+  assert.ok(versionCheck, "expected a git-version check");
+  assert.equal(versionCheck.status, "FAIL");
+  assert.match(versionCheck.detail, /does not support core\.hooksPath/);
+  // The hooks-path check itself can still legitimately show PASS - that's
+  // exactly the trap: config matches, but the hook never runs.
+  const hooksPathCheck = report.checks.find((check) => check.label === "hooks-path");
+  assert.equal(hooksPathCheck.status, "PASS");
+});
+
 async function createTempHome() {
   return mkdtemp(join(tmpdir(), "gforge-test-"));
 }


### PR DESCRIPTION
core.hooksPath was added in git 2.9. An older git accepts and stores the config key unconditionally but never consults it when running hooks, so install and verify would both report success while the scanner silently never runs on any commit - exactly the population most likely to be affected (enterprise/CI environments on an older distro-shipped git).

- Install now refuses to proceed on git < 2.9, with a clear message instead of a false "success".
- Verify now surfaces a FAIL git-version check even when hooks-path still reports PASS, since that PASS is exactly the trap: config matches, but the hook never runs on that git version.
- Version parsing tolerates platform-specific suffixes (e.g. "2.39.2 (Apple Git-143)" on macOS, "2.34.1.windows.1" on Windows) and fails closed on anything unparseable.

Fixes #51