### PR TITLE
Only run the postinstall global-hooks setup on an actual global install

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,6 +6,10 @@
 //
 // Safety rules:
 //   - Never fail the npm install: all errors are swallowed and we always exit 0.
+//   - Only act on an actual global install (npm_config_global === "true").
+//     A plain local `npm install gforge` in some unrelated project — or gforge
+//     showing up as a transitive/dev dependency of any package — must never
+//     rewrite the invoking machine's real, shared ~/.gitconfig.
 //   - Skip in CI / build images (process.env.CI) — reconfiguring global git there
 //     is pointless and surprising.
 //   - Honor GFORGE_SKIP_POSTINSTALL as an explicit escape hatch.
@@ -13,9 +17,20 @@
 //     the user to run `gforge install` if they want GForge to take it over.
 
 import { homedir } from "node:os";
+import { pathToFileURL } from "node:url";
+
+// Extracted so the "should we even touch global git config" decision is unit
+// testable without exercising the actual install side effects. Anything other
+// than the literal npm-set "true" is treated as "not a global install" -
+// fail closed towards leaving the machine's git config untouched.
+export function shouldRunPostinstall(env) {
+  if (env.npm_config_global !== "true") return false;
+  if (env.GFORGE_SKIP_POSTINSTALL || env.CI) return false;
+  return true;
+}
 
 async function main() {
-  if (process.env.GFORGE_SKIP_POSTINSTALL || process.env.CI) return;
+  if (!shouldRunPostinstall(process.env)) return;
 
   const home = homedir();
   if (!home) return;
@@ -51,10 +66,16 @@ async function main() {
   }
 }
 
-main()
-  .catch(() => {
-    // Never break `npm install` because of hook setup.
-  })
-  .finally(() => {
-    process.exit(0);
-  });
+// Only run (and only ever call process.exit) when npm actually executes this
+// file directly as the postinstall lifecycle script - not when something
+// (e.g. a test) imports it purely for the shouldRunPostinstall export.
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  main()
+    .catch(() => {
+      // Never break `npm install` because of hook setup.
+    })
+    .finally(() => {
+      process.exit(0);
+    });
+}

--- a/test/postinstall.test.js
+++ b/test/postinstall.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldRunPostinstall } from "../scripts/postinstall.js";
+
+test("issue #38: a plain local install (no -g) never touches global git config", () => {
+  // This is the exact bug: gforge as a local project dependency, or pulled in
+  // transitively by some unrelated package, must not run the global install.
+  assert.equal(shouldRunPostinstall({}), false);
+  assert.equal(shouldRunPostinstall({ npm_config_global: "false" }), false);
+  assert.equal(shouldRunPostinstall({ npm_config_global: undefined }), false);
+});
+
+test("runs on an actual global install with no other skip conditions", () => {
+  assert.equal(shouldRunPostinstall({ npm_config_global: "true" }), true);
+});
+
+test("still skips a global install in CI", () => {
+  assert.equal(shouldRunPostinstall({ npm_config_global: "true", CI: "true" }), false);
+});
+
+test("still honors the explicit GFORGE_SKIP_POSTINSTALL escape hatch on a global install", () => {
+  assert.equal(shouldRunPostinstall({ npm_config_global: "true", GFORGE_SKIP_POSTINSTALL: "1" }), false);
+});
+
+test("only the literal npm-set string \"true\" counts as global (fails closed)", () => {
+  // Anything else - a stray truthy-looking value, wrong casing, etc. - must
+  // not be treated as a global install.
+  assert.equal(shouldRunPostinstall({ npm_config_global: "1" }), false);
+  assert.equal(shouldRunPostinstall({ npm_config_global: "TRUE" }), false);
+});


### PR DESCRIPTION
postinstall.js unconditionally set the global core.hooksPath on any npm install of gforge - a plain local `npm install gforge` in an unrelated project, or gforge appearing anywhere in a dependency tree (a transitive/dev dependency of some other package), silently rewrote the invoking machine's real ~/.gitconfig. No -g flag was required.

Now gated on npm_config_global === "true", the standard npm-set env var for an actual global install; anything else (unset, "false", or any other value) fails closed and skips entirely. CI and the explicit GFORGE_SKIP_POSTINSTALL escape hatch continue to be honored on top of that.

Extracted the decision into an exported, unit-tested shouldRunPostinstall() rather than leaving it as inline, untested logic in a script that calls process.exit(). That required guarding the script's main() invocation to only fire on direct execution (node scripts/postinstall.js, exactly how npm's lifecycle runs it) - otherwise importing the file just to test the export was itself terminating the test process via that same exit call, which is a real trap worth calling out for whoever touches this file next.

Fixes #38