### PR TITLE
Close the trivial self-reference bypass of the generic secret rule

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -176,13 +176,34 @@ function looksLikeRouteTemplate(value) {
 // secret cannot appear inside the identifier that names it, whereas the reverse
 // would suppress a real one (AUTH = "s3cr3tAuthValue123") (issue #23).
 const KEY_IDENTIFIER_RE = /([A-Za-z_][\w.$-]*)\s*["'`]?\s*[:=]\s*$/;
+
+// A genuine self-referential label restates its own name as a plain,
+// human-readable word or slug (SESSION_KEY = "session-key"). That must not be
+// confused with a real secret that merely happens to be substring-contained
+// in a longer identifier which *also* carries the very credential keyword
+// that triggered this rule in the first place — db_password_hunter2Real9 =
+// "hunter2!Real9" is not a label restating its name, it is the same secret
+// one rename away from invisibility, for a secret of any length (issue #37).
+// A hand-written label never carries digits or symbol characters; a real
+// generated secret almost always does — so the substring match alone is not
+// enough, the value itself must still look like a plain word/slug.
+const SELF_LABEL_RE = /^[A-Za-z][A-Za-z_-]*$/;
+const SELF_LABEL_MIN_VOWEL_RATIO = 0.3;
+function looksLikeSelfDescriptiveLabel(value) {
+  if (!SELF_LABEL_RE.test(value)) return false;
+  const letters = value.replace(/[^A-Za-z]/g, "");
+  if (letters.length < 4) return false;
+  return ratioOf(letters, /[aeiou]/gi) >= SELF_LABEL_MIN_VOWEL_RATIO;
+}
+
 function echoesItsKey(value, keyContext) {
   if (!keyContext) return false;
   const key = keyContext.match(KEY_IDENTIFIER_RE);
   if (!key) return false;
   const flatten = (text) => text.toLowerCase().replace(/[^a-z0-9]/g, "");
   const flatValue = flatten(value);
-  return flatValue.length >= 4 && flatten(key[1]).includes(flatValue);
+  if (flatValue.length < 4 || !flatten(key[1]).includes(flatValue)) return false;
+  return looksLikeSelfDescriptiveLabel(value);
 }
 
 // Decide whether the value assigned to a credential keyword is a hardcoded

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -330,6 +330,27 @@ test("issue #23: the same shapes carrying a REAL credential are still blocked", 
   assert.ok(ruleIds("a.js", `const token = "abc123def456" // user's key`).includes(GENERIC_SECRET_RULE_ID));
 });
 
+test("issue #37: appending the literal secret to a credential-keyword identifier is not a self-referential label", () => {
+  const secret = "hunter2!Real9";
+  // Same secret, same shape as the legitimate self-label exemption (the value
+  // is substring-contained in the key) - but the "extra" part of the key is
+  // the very credential keyword that made this a hardcoded-secret candidate
+  // in the first place, and the value itself is not a plain word/slug.
+  assert.ok(ruleIds("config.js", `const ${secret}_password = "${secret}";`).includes(GENERIC_SECRET_RULE_ID));
+  // Digits alone are enough to disqualify the exemption, even with no symbol
+  // character anywhere in the secret.
+  assert.ok(ruleIds("config.js", 'const A1b2c3d4e5_password = "A1b2c3d4e5";').includes(GENERIC_SECRET_RULE_ID));
+  // The legitimate exemption this rule exists for must still hold: a plain
+  // word/slug that merely restates its own name is still a label, not a
+  // credential.
+  assert.equal(ruleIds("config.js", 'const SESSION_KEY = "session-key";').length, 0);
+  assert.equal(
+    ruleIds("keys.ts", 'export const CALL_HISTORY_SKIP_DEFAULT_FILTERS_SESSION_KEY = "call-history-skip-default-filters";')
+      .length,
+    0
+  );
+});
+
 test("inline gforge:allow suppresses a line", () => {
   assert.equal(ruleIds("a", "DB_PASS=psspl@443e # gforge:allow").length, 0);
   assert.equal(ruleIds("a", "DB_PASS=psspl@443e // gitleaks:allow").length, 0);


### PR DESCRIPTION
echoesItsKey() exempted any value that was substring-contained in its own key, meant only to cover a constant restating its own name (SESSION_KEY = "session-key"). But that substring check alone can't tell that case apart from a real secret appended directly to a credential-keyword identifier - db_password_hunter2Real9 = "..." (or appended before the keyword, same effect) - since both shapes are structurally identical: value substring-contained in a longer identifier that also carries the keyword that triggered the rule.

The actual signal is the value itself: a hand-written label is a plain word/slug (letters, hyphens/underscores, vowel-rich); a real generated secret almost always carries digits or symbol characters. So the exemption now also requires the value to look like a plain word/slug, not just be substring-contained in the key - closing the bypass for secrets of any length while leaving the original, documented exemption intact.

Note: the issue's own literal repro (db_password_hunter2Real9, keyword appended mid-identifier) happens to also trip the separate, still-open #27 (compound camelCase identifiers aren't recognized by the keyword regex at all in that shape) - verified by testing the regex directly. Confirmed a clean, unconfounded reproduction of the actual echoesItsKey mechanism (keyword at the tail of the identifier, as required by the existing regex) and used that for the test instead.

Fixes #37