### PR TITLE
Recognize compound camelCase credential identifiers

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -107,7 +107,68 @@ export const PROVIDER_RULES = [
 // purpose and train developers to bypass the hook.
 export const GENERIC_SECRET_RULE_ID = "generic-secret-assignment";
 const GENERIC_SECRET_DESCRIPTION = "hardcoded value assigned to a credential keyword";
-const GENERIC_KEYWORD_RE = /(?:^|[^A-Za-z0-9])(?:passwd|password|passphrase|pwd|pass|secret(?:[_-]?key)?|token|access[_-]?token|auth(?:[_-]?token)?|authorization|bearer|api[_-]?key|apikey|access[_-]?key|client[_-]?secret|private[_-]?key|encryption[_-]?key|signing[_-]?key|session[_-]?key|connection[_-]?string|conn[_-]?str|credentials?)["'`]?\s*[:=]\s*(\S.*)$/i;
+// The keyword itself, with no boundary and no trailing context — matched
+// case-insensitively, globally, so every occurrence in a line can be tried.
+// Boundary and trailing-segment checks are done separately in plain JS
+// below (see matchGenericKeyword), NOT as part of this pattern: character
+// classes inside lookarounds are also flattened by the /i flag, so a
+// lookaround here could never actually tell upper- from lowercase to detect
+// a camelCase transition (verified directly against V8 before writing this).
+// Order matters: unlike the original single-pattern regex (where a failed
+// tail check let the engine backtrack into a later, longer alternative at
+// the same position for free), matchGenericKeyword below commits to
+// whichever alternative matches first and does not retry other alternatives
+// at that same position. So wherever one alternative is a prefix of another
+// (authorization vs. auth), the longer/more specific one must be listed
+// first, or "Authorization: Bearer ..." would match only "auth" and then
+// fail its own tail check instead of matching "authorization" and succeeding.
+const GENERIC_KEYWORD_CORE_RE = /(?:passwd|password|passphrase|pwd|pass|secret(?:[_-]?key)?|token|access[_-]?token|authorization|auth(?:[_-]?token)?|bearer|api[_-]?key|apikey|access[_-]?key|client[_-]?secret|private[_-]?key|encryption[_-]?key|signing[_-]?key|session[_-]?key|connection[_-]?string|conn[_-]?str|credentials?)/gi;
+
+// At most one trailing camelCase segment right after the keyword (the
+// "Value" in clientSecretValue) — deliberately not unbounded, so the match
+// cannot run through an unrelated compound tail (apiSecretKeyRotationInterval)
+// to reach a distant, unrelated "=".
+const TRAILING_CAMEL_SEGMENT_RE = /^[A-Z][a-z0-9]*/;
+// What must follow the keyword (and its optional trailing segment) for this
+// to be an assignment at all, same shape the original regex required.
+const KEYWORD_TAIL_RE = /^["'`]?\s*[:=]\s*(\S.*)$/;
+
+function isAsciiUpper(ch) {
+  return ch !== undefined && ch >= "A" && ch <= "Z";
+}
+function isAsciiLowerOrDigit(ch) {
+  return ch !== undefined && ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9"));
+}
+
+// Finds a credential-keyword assignment anywhere in `line`, tolerating a
+// camelCase compound identifier (apiSecretKey, clientSecretValue) in
+// addition to the original start-of-line/non-alphanumeric-boundary forms
+// (snake_case, ALL_CAPS, plain) — issue #27. Returns the captured value, or
+// null. Loops past a candidate whose boundary or tail doesn't hold, rather
+// than giving up after the first (leftmost) keyword-shaped substring.
+function matchGenericKeyword(line) {
+  GENERIC_KEYWORD_CORE_RE.lastIndex = 0;
+  let found;
+  while ((found = GENERIC_KEYWORD_CORE_RE.exec(line))) {
+    const start = found.index;
+    const end = start + found[0].length;
+
+    const before = line[start - 1];
+    const boundaryOk =
+      start === 0 ||
+      !/[A-Za-z0-9]/.test(before) ||
+      (isAsciiLowerOrDigit(before) && isAsciiUpper(line[start]));
+    if (!boundaryOk) continue;
+
+    const rest = line.slice(end);
+    const segment = rest.match(TRAILING_CAMEL_SEGMENT_RE);
+    const afterKeyword = segment ? rest.slice(segment[0].length) : rest;
+
+    const tail = afterKeyword.match(KEYWORD_TAIL_RE);
+    if (tail) return tail[1];
+  }
+  return null;
+}
 // Placeholder shapes shared by the generic rule and the .env cross-reference.
 // These two lists had drifted: the dotenv layer knew `your_db_password` was a
 // placeholder while the generic rule did not, so every `KEY=your_*` line in a
@@ -507,11 +568,11 @@ export function scanText(filePath, content, options = {}) {
     }
 
     if (includeGeneric) {
-      const match = line.match(GENERIC_KEYWORD_RE);
+      const value = matchGenericKeyword(line);
       // Everything left of the value: the capture runs to end of line, so the
       // remainder names the key the value was assigned to.
-      const keyContext = match ? line.slice(0, line.length - match[1].length) : "";
-      if (match && looksLikeHardcodedSecret(match[1], { codeFile, keyContext })) {
+      const keyContext = value !== null ? line.slice(0, line.length - value.length) : "";
+      if (value !== null && looksLikeHardcodedSecret(value, { codeFile, keyContext })) {
         findings.push({
           file: filePath,
           line: lineNumber,

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -33,6 +33,35 @@ test("detects a variety of hardcoded password/credential assignments", () => {
   assert.ok(ruleIds("a.env", "SESSION_KEY=9f8e7d6c5b4a3210").includes("generic-secret-assignment"));
 });
 
+test("issue #27: a compound camelCase identifier does not hide the credential keyword", () => {
+  // The exact reported cases: the keyword sits mid-identifier, preceded by a
+  // lowercase letter, which the original boundary (start-of-line or
+  // non-alphanumeric) never matched.
+  assert.ok(ruleIds("a.js", "const apiSecretKey = 'Sup3rS3cretV4lue';").includes(GENERIC_SECRET_RULE_ID));
+  assert.ok(ruleIds("a.js", "const wbAccessToken = 'Sup3rS3cretV4lue';").includes(GENERIC_SECRET_RULE_ID));
+  assert.ok(ruleIds("a.js", "const clientSecretValue = 'Sup3rS3cretV4lue';").includes(GENERIC_SECRET_RULE_ID));
+  assert.ok(ruleIds("a.js", "apiSecretKey: 'Sup3rS3cretV4lue',").includes(GENERIC_SECRET_RULE_ID));
+  // A real occurrence from the issue: a commented-out assignment using the
+  // same naming convention still finds the keyword.
+  assert.ok(ruleIds("a.js", "// const wbAccessToken = 'Sup3rS3cretV4lue';").includes(GENERIC_SECRET_RULE_ID));
+});
+
+test("issue #27: the compound-identifier match stays bounded, not a license to match anything containing the keyword", () => {
+  // "ApiKey" is a coincidental prefix of "Keyboard" here - the word after it
+  // is lowercase, not a fresh camelCase segment, so it must not be treated as
+  // a continuation of the keyword match.
+  assert.equal(ruleIds("a.js", "const ApiKeyboardShortcut = 'cmd+k';").length, 0);
+  // Only one trailing camelCase segment is tolerated (the "Value" in
+  // clientSecretValue) - a longer unrelated compound tail must not let the
+  // match run all the way to a distant, unrelated "=".
+  assert.equal(ruleIds("a.js", "apiSecretKeyRotationInterval = 86400;").length, 0);
+  // Snake_case identifiers where the keyword is not the last segment before
+  // "=" must keep behaving exactly as before this fix (no new match, since
+  // this shape was never part of the reported bug and camelCase-only
+  // continuation deliberately does not extend to underscore segments).
+  assert.equal(ruleIds("a.js", "password_reset_enabled = true;").length, 0);
+});
+
 test("does not flag credential keys wired to env vars / references (well-written config)", () => {
   // The critical real-world case: Sequelize/config files that read secrets from
   // the environment must NOT be blocked.


### PR DESCRIPTION
The generic secret-assignment rule required its keyword (password, secret, token, ...) to sit at start-of-line or right after a non-alphanumeric character. In camelCase compounds like apiSecretKey or wbAccessToken, the keyword is preceded by a lowercase letter, so it never matched at all - a live credential named this way was invisible to every layer (the value's entropy can also fall under the entropy threshold, as it does in the issue's own example).

Rewrote the match as two phases instead of one regex: a case- insensitive scan for the keyword anywhere in the line, then a plain-JS boundary/trailing check against the line's actual (non-flattened) case. That split was necessary, not stylistic - a regex lookaround for an upper/lowercase transition is useless once the overall pattern carries the /i flag, since character classes inside lookarounds are flattened by it too (confirmed directly against V8 before writing this, since assuming otherwise would have shipped a check that can never fire).

The trailing side only tolerates exactly one extra camelCase segment after the keyword (the "Value" in clientSecretValue) - deliberately not unbounded, so the match can't run through an unrelated compound tail (apiSecretKeyRotationInterval) to reach a distant "=". Confirmed this doesn't flag "ApiKeyboardShortcut" (a coincidental prefix match) or "password_reset_enabled" (snake_case, keyword not at the tail, same as before this fix), and added both as permanent regression tests.

Splitting the match into two phases also surfaces a keyword-ordering requirement that used to be papered over by regex backtracking: since the boundary/tail check no longer lets the engine fall back to a different alternative at the same position, a shorter alternative that is a literal prefix of a longer one (auth vs. authorization) must be listed after it, or "Authorization: Bearer ..." stops matching. Reordered auth/authorization accordingly and confirmed the existing Authorization: Bearer test (and the rest of the suite) still passes.

Fixes #27