### PR TITLE
Cross-reference every .env in the repo, not just the root one

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ so the standard is enforced by default, not by discipline.
   so the firewall applies to every repository on the machine.
 - **Deep, layered detection**
   - **`.env` cross-reference** — blocks any staged file that hardcodes a real value
-    from your git-ignored `.env` files (the classic "pasted a token out of `.env`").
+    from your git-ignored `.env` files (the classic "pasted a token out of `.env`"),
+    including per-package `.env` files in a monorepo, not just the repo root.
   - **Provider rules** — 25+ credential shapes: AWS, GitHub/GitLab, Google, Slack,
     Stripe, Twilio, SendGrid, npm, PyPI, OpenAI/Anthropic, PEM private keys, JWTs,
     database URLs, and more.
@@ -90,7 +91,7 @@ gforge <command> [--force]
 | Command | Description |
 | --- | --- |
 | `gforge install` | Upgrade to the latest version (if any) and install the global hooks. |
-| `gforge verify` | Read-only health check of the environment and installed hooks. |
+| `gforge verify` | Read-only health check of the environment, the installed hooks, and (inside a repo) the `.env` files the cross-reference can see. |
 | `gforge update` | Upgrade to the latest version (if any) and refresh the hooks. |
 | `gforge uninstall` | Remove GForge-owned hooks and restore your previous Git config. |
 | `gforge version` | Print the installed version. |
@@ -108,6 +109,10 @@ value**. Detection runs several layers in order:
 
 1. **`.env` cross-reference** — the highest-precision signal: values read (in
    memory only) from your git-ignored `.env` files, matched verbatim in staged code.
+   Every `.env` in the repository is used, not only the root one, so a monorepo's
+   `server/.env` and `client/.env` are covered. Template files are skipped, and
+   the search prunes vendored and build directories (`node_modules`, `dist`, …).
+   `gforge verify` prints which `.env` files this layer found.
 2. **Provider rules** — fixed credential shapes for the major cloud and SaaS providers.
 3. **Generic secrets** — credential keywords assigned to a hardcoded value; smart
    enough to ignore `process.env.*`, function calls, `${VAR}` interpolation, and

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ import {
   performSelfUpgrade,
   readCachedUpdateNotice
 } from "./npm-update.js";
+import { describeDotenvSources } from "./scanner.js";
 import { createVerificationReport, formatVerificationReport } from "./verify.js";
 
 export async function runCli(args, streams, options = {}) {
@@ -42,7 +43,8 @@ export async function runCli(args, streams, options = {}) {
       ...options,
       environment
     });
-    const report = createVerificationReport(environment, managedHooksReport);
+    const dotenvReport = (options.describeDotenvSources ?? describeDotenvSources)();
+    const report = createVerificationReport(environment, managedHooksReport, dotenvReport);
 
     streams.stdout.write(formatVerificationReport(report));
     const notice = (options.readCachedUpdateNotice ?? readCachedUpdateNotice)(VERSION);

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -58,9 +58,9 @@ export function isHeuristicExemptPath(filePath, env = process.env) {
 // rule identifiers.
 
 import { execFileSync, spawn } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 // Baked at install time (see getScannerContent in hooks.js). Left as a literal
@@ -673,13 +673,18 @@ function stagedContent(filePath) {
   }
 }
 
-function loadAllowlist() {
-  let root;
+// The working-tree root, or null when not inside a git repository.
+function repoRoot() {
   try {
-    root = git(["rev-parse", "--show-toplevel"]).toString("utf8").trim();
+    return git(["rev-parse", "--show-toplevel"]).toString("utf8").trim() || null;
   } catch {
-    return [];
+    return null;
   }
+}
+
+function loadAllowlist() {
+  const root = repoRoot();
+  if (!root) return [];
   const patterns = [];
   for (const file of [".gforgeignore", ".gitleaksignore"]) {
     const content = stagedOrWorkingFile(root, file);
@@ -704,11 +709,25 @@ function stagedOrWorkingFile(root, relPath) {
 // VALUES from the repo's (git-ignored) .env files, then flag any staged file
 // that hardcodes one of those values verbatim — the classic "copied the token
 // out of .env into the code" leak. Values are never printed.
+//
+// Env files live next to the package that owns them. A monorepo keeps them in
+// subdirectories (server/.env, client/.env, ...) and frequently has no root
+// .env at all, so reading a fixed list of filenames in the repo root loaded
+// zero secrets and silently disabled this whole layer (issue #26). The repo is
+// walked instead, bounded by depth, directory budget and the generated/vendor
+// skip list so a large tree cannot slow a commit down.
 // ---------------------------------------------------------------------------
-const DOTENV_FILES = [
-  ".env", ".env.local", ".env.development", ".env.production",
-  ".env.staging", ".env.test", ".env.development.local", ".env.production.local"
-];
+const DOTENV_MAX_DEPTH = 5;
+// Reached only by a repo with thousands of non-vendored directories; a tree
+// that large costs a few hundred ms to walk, and a normal one a few tens.
+const DOTENV_MAX_DIRECTORIES = 4000;
+const DOTENV_MAX_BYTES = 1024 * 1024;
+// Build output, vendored dependencies and virtualenvs hold other projects'
+// env files, not this repo's — and are where the file count explodes.
+const DOTENV_SKIP_DIRECTORIES = new Set([
+  ...GENERATED_DIRECTORIES, ".git", ".hg", ".svn", ".venv", "venv", "virtualenv",
+  ".tox", ".gradle", ".terraform", ".cache", ".yarn", ".pnpm-store", "pods"
+]);
 const DOTENV_KEY_IS_SECRET = /(pass|pwd|secret|token|key|auth|cred|api|private|access|signature|salt)/i;
 // Shares PLACEHOLDER_ALTERNATIVES with the generic rule (see issue #25); the
 // extras here are environment-ish values that are real but not secret.
@@ -726,18 +745,72 @@ function looksLikeDotenvSecret(key, value) {
   return value.length >= 12 && /[A-Za-z]/.test(value) && /[0-9]/.test(value);
 }
 
-function loadDotenvSecrets() {
-  let root;
-  try {
-    root = git(["rev-parse", "--show-toplevel"]).toString("utf8").trim();
-  } catch {
-    return [];
+// A real env file: `.env`, or `.env.<anything>` that is not a placeholder
+// template. Templates are tracked and hold fake values, so cross-referencing
+// them would block commits on the very placeholders issue #25 taught us to
+// ignore.
+export function isDotenvFile(filePath) {
+  const name = basename(filePath).toLowerCase();
+  if (name === ".env") return true;
+  return name.startsWith(".env.") && !isEnvTemplate(name);
+}
+
+// Every env file in the repo. Breadth-first on purpose: env files sit at
+// package roots, so if a pathological tree exhausts the directory budget it is
+// the deepest directories that go unread, never a sibling package's .env.
+export function collectDotenvFiles(root) {
+  const found = [];
+  let queue = [root];
+  let depth = 0;
+  let budget = DOTENV_MAX_DIRECTORIES;
+
+  while (queue.length > 0 && budget > 0) {
+    const next = [];
+
+    for (const directory of queue) {
+      if (budget <= 0) break;
+      budget -= 1;
+
+      let entries;
+      try {
+        entries = readdirSync(directory, { withFileTypes: true });
+      } catch {
+        continue; // unreadable directory (permissions, race); nothing to load here.
+      }
+
+      for (const entry of entries) {
+        // Symlinks report as neither file nor directory here, which also keeps
+        // the walk free of symlink loops.
+        if (entry.isDirectory()) {
+          if (depth >= DOTENV_MAX_DEPTH) continue;
+          if (DOTENV_SKIP_DIRECTORIES.has(entry.name.toLowerCase())) continue;
+          next.push(join(directory, entry.name));
+        } else if (entry.isFile() && isDotenvFile(entry.name)) {
+          found.push(join(directory, entry.name));
+        }
+      }
+    }
+
+    queue = next;
+    depth += 1;
   }
+
+  return found;
+}
+
+export function loadDotenvSecrets(root = repoRoot()) {
+  return root ? dotenvSecretsFrom(collectDotenvFiles(root)) : [];
+}
+
+function dotenvSecretsFrom(files) {
   const secrets = new Set();
-  for (const file of DOTENV_FILES) {
+  for (const file of files) {
     let text;
     try {
-      text = decodeBlob(readFileSync(`${root}/${file}`));
+      // An env file is a handful of lines; anything larger is not one, and
+      // reading it would stall the commit.
+      if (statSync(file).size > DOTENV_MAX_BYTES) continue;
+      text = decodeBlob(readFileSync(file));
     } catch {
       continue;
     }
@@ -755,6 +828,21 @@ function loadDotenvSecrets() {
     }
   }
   return [...secrets];
+}
+
+// What the cross-reference can actually see, for `gforge verify`. A layer that
+// silently loads nothing is indistinguishable from one that is working, which
+// is how the monorepo gap went unnoticed (issue #26). Reports file paths and
+// counts only — never a value.
+export function describeDotenvSources(root = repoRoot()) {
+  if (!root) return { inRepo: false, root: null, files: [], secretCount: 0 };
+  const files = collectDotenvFiles(root);
+  return {
+    inRepo: true,
+    root,
+    files: files.map((file) => relative(root, file).replace(/\\/g, "/")).sort(),
+    secretCount: dotenvSecretsFrom(files).length
+  };
 }
 
 function lineOfSubstring(content, needle) {

--- a/src/verify.js
+++ b/src/verify.js
@@ -1,4 +1,4 @@
-export function createVerificationReport(environment, managedHooksReport = null) {
+export function createVerificationReport(environment, managedHooksReport = null, dotenvReport = null) {
   const checks = [
     {
       status: environment.platform.supported ? "PASS" : "FAIL",
@@ -22,12 +22,49 @@ export function createVerificationReport(environment, managedHooksReport = null)
     }
   ];
 
-  const allChecks = managedHooksReport ? [...checks, ...managedHooksReport.checks] : checks;
+  const allChecks = [
+    ...checks,
+    ...(managedHooksReport ? managedHooksReport.checks : []),
+    ...dotenvChecks(dotenvReport)
+  ];
 
   return {
     checks: allChecks,
     exitCode: allChecks.some((check) => check.status === "FAIL") ? 1 : 0
   };
+}
+
+// The .env cross-reference is the scanner's highest-precision layer, and it is
+// inert whenever no .env file is readable — a monorepo with only per-package
+// env files used to report perfect health while catching nothing (issue #26).
+// Verification says what the layer can see: paths and counts, never values.
+// Nothing is reported outside a git repository, where there is no repo to read.
+function dotenvChecks(report) {
+  if (!report || !report.inRepo) return [];
+
+  const label = "dotenv-cross-reference";
+  if (report.files.length === 0) {
+    return [{ status: "WARN", label, detail: "no .env file found in this repository; layer inactive" }];
+  }
+  if (report.secretCount === 0) {
+    return [{
+      status: "WARN",
+      label,
+      detail: `${formatFileList(report.files)} hold no secret-shaped values; layer inactive`
+    }];
+  }
+
+  return [{
+    status: "PASS",
+    label,
+    detail: `${report.secretCount} value(s) cross-referenced from ${formatFileList(report.files)}`
+  }];
+}
+
+function formatFileList(files, limit = 4) {
+  const shown = files.slice(0, limit).join(", ");
+  const rest = files.length - limit;
+  return rest > 0 ? `${files.length} env files (${shown}, +${rest} more)` : shown;
 }
 
 export function formatVerificationReport(report) {

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
 import test from "node:test";
 
 import {
   GENERIC_SECRET_RULE_ID,
+  collectDotenvFiles,
   decodeBlob,
+  describeDotenvSources,
   entropyCandidates,
   formatReport,
+  isDotenvFile,
   isHeuristicExemptPath,
   isEnvTemplate,
+  loadDotenvSecrets,
   matchFilenameRule,
   parseAllowlist,
   scanStaged,
@@ -488,6 +495,68 @@ test("cross-references staged code against .env secret values", () => {
   assert.equal(clean.findings.length, 0);
 });
 
+test("cross-references .env files in package subdirectories, not just the repo root", () => {
+  // The monorepo layout from issue #26: no root .env at all, one per package.
+  const root = makeTree({
+    "server/.env": "DB_PASSWORD=Sup3rS3cretMonoValue\n",
+    "client/.env.local": "VITE_API_TOKEN=clientTok3nAbcdef123456\n",
+    "server/.env.example": "DB_PASSWORD=your_db_password\n", // template: placeholders only
+    "node_modules/some-pkg/.env": "PKG_SECRET=vendoredValue1234\n", // another project's secrets
+    "dist/.env": "BUILD_SECRET=generatedValue1234\n"
+  });
+
+  assert.deepEqual(relativeDotenvFiles(root), ["client/.env.local", "server/.env"]);
+
+  const secrets = loadDotenvSecrets(root);
+  assert.ok(secrets.includes("Sup3rS3cretMonoValue"));
+  assert.ok(secrets.includes("clientTok3nAbcdef123456"));
+  assert.equal(secrets.includes("your_db_password"), false);
+  assert.equal(secrets.includes("vendoredValue1234"), false);
+
+  // End to end: a value pasted out of server/.env into server code is blocked.
+  const leak = scanStaged({
+    ...opts, allowlist: [], dotenvSecrets: secrets,
+    files: ["server/src/db.js"], read: () => 'const pw = "Sup3rS3cretMonoValue";'
+  });
+  assert.ok(leak.findings.some((f) => f.ruleId === "hardcoded-dotenv-secret"));
+  assert.doesNotMatch(formatReport(leak), /Sup3rS3cretMonoValue/);
+});
+
+test("recognizes real env files and skips placeholder templates", () => {
+  assert.ok(isDotenvFile(".env"));
+  assert.ok(isDotenvFile("server/.env.production.local"));
+  assert.ok(isDotenvFile(".env.staging"));
+  assert.equal(isDotenvFile(".env.example"), false);
+  assert.equal(isDotenvFile(".env.local.template"), false);
+  assert.equal(isDotenvFile("env"), false);
+  assert.equal(isDotenvFile("environment.js"), false);
+});
+
+test("bounds the .env walk so a deep tree cannot stall a commit", () => {
+  const root = makeTree({
+    "a/b/c/d/e/.env": "DEEP_TOKEN=deepValue12345678\n",
+    "a/b/c/d/e/f/.env": "TOO_DEEP_TOKEN=tooDeepValue12345\n"
+  });
+
+  const found = relativeDotenvFiles(root);
+  assert.deepEqual(found, ["a/b/c/d/e/.env"]);
+});
+
+test("reports what the .env cross-reference can see, so a dead layer is visible", () => {
+  const populated = describeDotenvSources(makeTree({ "server/.env": "API_KEY=serverValue1234\n" }));
+  assert.equal(populated.inRepo, true);
+  assert.deepEqual(populated.files, ["server/.env"]);
+  assert.equal(populated.secretCount, 1);
+
+  const empty = describeDotenvSources(makeTree({ "server/index.js": "export default 1;\n" }));
+  assert.equal(empty.inRepo, true);
+  assert.deepEqual(empty.files, []);
+  assert.equal(empty.secretCount, 0);
+
+  // Outside a git repository there is nothing to describe.
+  assert.deepEqual(describeDotenvSources(null), { inRepo: false, root: null, files: [], secretCount: 0 });
+});
+
 test("decodes UTF-16/BOM blobs so Windows/PowerShell files are scanned", () => {
   const secret = "password=SuperSecretValue123";
   const utf16le = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(`${secret}\n`, "utf16le")]);
@@ -509,3 +578,21 @@ test("shannon entropy scores random strings above plain text", () => {
   assert.ok(shannonEntropy("Zx9Kq2mVbN7pLwR4tYaSdFgHjKl") > 4.2);
   assert.ok(shannonEntropy("aaaaaaaaaaaaaaaaaaaa") < 1);
 });
+
+// Materializes { "relative/path": "content" } under a fresh temp directory and
+// returns its root, for the .env discovery tests.
+function makeTree(files) {
+  const root = mkdtempSync(join(tmpdir(), "gforge-dotenv-"));
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(root, path);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return root;
+}
+
+function relativeDotenvFiles(root) {
+  return collectDotenvFiles(root)
+    .map((file) => relative(root, file).split(/[\\/]/).join("/"))
+    .sort();
+}

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -20,6 +20,48 @@ test("creates successful report when required checks pass", () => {
   assert.equal(report.checks.every((check) => check.status === "PASS"), true);
 });
 
+test("reports the .env cross-reference so a silently dead layer is visible", () => {
+  const monorepo = createVerificationReport(healthyEnvironment(), null, {
+    inRepo: true,
+    root: "/repo",
+    files: ["client/.env", "server/.env"],
+    secretCount: 7
+  });
+  const output = formatVerificationReport(monorepo);
+
+  assert.equal(monorepo.exitCode, 0);
+  assert.match(output, /PASS dotenv-cross-reference: 7 value\(s\) cross-referenced from client\/\.env, server\/\.env/);
+
+  // No .env anywhere: the layer loads nothing, and verification must say so.
+  const inactive = createVerificationReport(healthyEnvironment(), null, {
+    inRepo: true,
+    root: "/repo",
+    files: [],
+    secretCount: 0
+  });
+  assert.equal(inactive.exitCode, 0); // informational: a repo may legitimately have none
+  assert.match(formatVerificationReport(inactive), /WARN dotenv-cross-reference: no \.env file found/);
+
+  // Files found, but nothing secret-shaped in them: still inert.
+  const empty = createVerificationReport(healthyEnvironment(), null, {
+    inRepo: true,
+    root: "/repo",
+    files: [".env"],
+    secretCount: 0
+  });
+  assert.match(formatVerificationReport(empty), /WARN dotenv-cross-reference: \.env hold no secret-shaped values/);
+
+  // Outside a git repository the check is omitted entirely.
+  const outside = createVerificationReport(healthyEnvironment(), null, {
+    inRepo: false,
+    root: null,
+    files: [],
+    secretCount: 0
+  });
+  assert.equal(outside.checks.some((check) => check.label === "dotenv-cross-reference"), false);
+  assert.equal(createVerificationReport(healthyEnvironment()).checks.some((c) => c.label === "dotenv-cross-reference"), false);
+});
+
 test("formats warnings without failing verification", () => {
   const report = createVerificationReport({
     platform: { name: "linux", arch: "x64", supported: true },
@@ -31,3 +73,12 @@ test("formats warnings without failing verification", () => {
   assert.equal(report.exitCode, 0);
   assert.match(formatVerificationReport(report), /WARN shell: not detected/);
 });
+
+function healthyEnvironment() {
+  return {
+    platform: { name: "linux", arch: "x64", supported: true },
+    home: { path: "/home/example", present: true },
+    shell: { path: "/bin/bash", name: "bash", supported: true },
+    git: { available: true, rawVersion: "git version 2.45.0" }
+  };
+}


### PR DESCRIPTION
The .env cross-reference resolved the repo root and read a hardcoded list of eight filenames directly under it. Nothing else was ever opened, so in a monorepo whose env files live in package directories (server/.env, client/.env, ...) the highest-precision layer loaded zero values and did nothing - and nothing anywhere said so. Confirmed by reproduction before touching the code: a value pasted out of server/.env produced zero findings, while the identical value with a root .env was blocked as hardcoded-dotenv-secret. Same secret, same code, same repo - only the .env location differed.

Discovery is now a bounded breadth-first walk of the working tree. Breadth-first is load-bearing, not stylistic: env files sit at package roots, so when a very large tree exhausts the directory budget it is the deepest directories that go unread, never a sibling package's .env (verified on a 2500-package tree - every package root is read before the walk descends). Bounds are depth 5, 4000 directories and 1 MiB per file, with vendored and build trees pruned by reusing the existing GENERATED_DIRECTORIES set: measured at 37 ms over an 8643-directory tree, 276 ms in the pathological 2500-package case. Symlinked directories are skipped, which also makes symlink loops impossible.

Any real env file now counts instead of eight fixed names - .env.prod and .env.dev.local were invisible even at the root before. Templates are excluded through the existing isEnvTemplate, which also drops .env.test: it sat in the old list while ALLOWED_ENV_SUFFIXES already classified .test as a template. That costs no detection, since a committed file's values are in the repo already, and it removes a latent false positive where a committed .env.test value legitimately reused in test code would have blocked the commit.

The silent-failure half of the issue is handled separately: gforge verify now reports what the layer can actually see - paths and counts, never values - warning when no env file is found, and warning separately when the files found hold nothing secret-shaped. The check is omitted outside a git repository and never affects the exit code.

Re-established the issue afterwards on the reporter's exact layout (server, client, call-assistant-extension, each with a gitignored .env and a tracked .env.example): all three pastes are now caught by name through the real hook entry point, the staged templates are correctly ignored, no value appears in any output, and a clean file in the same monorepo still commits.

Fixes #26