### PR TITLE
Detect system-level core.hooksPath and warn about dormant classic hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,21 @@ file to manage.
 | `GFORGE_NODE=/path/to/node` | Pin the Node.js runtime the hook uses. |
 | `GFORGE_NO_DEFAULT_EXCLUDES=1` | Run the heuristic layers on every path, including translations, docs, and build output. |
 
-If a repository or the system already defines its own `core.hooksPath` (e.g. Husky
-or lefthook), GForge does not override it; run `gforge install` to have GForge take
-over. Automatic setup is skipped in CI (`CI` environment variable).
+If a repository, or the system itself, already defines its own `core.hooksPath`
+(e.g. Husky or lefthook, or an org policy pushed via `GIT_CONFIG_SYSTEM`), the
+automatic `npm install` setup does not override it — global config outranks
+system config in git's own precedence, so writing a global value would silently
+shadow a system-level one even without touching it directly, and the automatic
+setup checks for that too. Run `gforge install` to have GForge take over
+explicitly. Automatic setup is skipped in CI (`CI` environment variable).
+
+A **classic, hand-written** `.git/hooks/pre-commit` script (one that predates
+GForge and isn't itself managed by a tool like Husky) is a different case: git
+only ever consults one `core.hooksPath` location, so once GForge's global path
+is active, a script sitting directly in a repository's own `hooks/` directory
+goes dormant — there's no config value there for GForge to detect and preserve.
+`gforge verify` checks for this and reports a `classic-hook-shadowed` warning
+when it finds one, so it doesn't fail silently.
 
 ## Cross-platform support
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -15,6 +15,10 @@
 //   - Honor GFORGE_SKIP_POSTINSTALL as an explicit escape hatch.
 //   - Never silently clobber an existing, non-GForge global core.hooksPath; tell
 //     the user to run `gforge install` if they want GForge to take it over.
+//   - Same for a system-level core.hooksPath (e.g. org policy pushed via
+//     GIT_CONFIG_SYSTEM): global outranks system in git's real precedence, so
+//     writing a global value here would silently shadow it even though the
+//     system file itself is never touched (issue #41).
 
 import { homedir } from "node:os";
 import { pathToFileURL } from "node:url";
@@ -29,24 +33,42 @@ export function shouldRunPostinstall(env) {
   return true;
 }
 
+// What (if anything) already occupies the hooksPath GForge would otherwise
+// take over, described for the user - or null if it is safe to proceed.
+// Extracted for the same reason as shouldRunPostinstall: testable without
+// exercising real git calls.
+export function describeExistingHooksPath(currentGlobal, currentSystem, hooksDirectory) {
+  if (currentGlobal && currentGlobal !== hooksDirectory) {
+    return `a global core.hooksPath is already set (${currentGlobal})`;
+  }
+  if (!currentGlobal && currentSystem && currentSystem !== hooksDirectory) {
+    return `a system-level core.hooksPath is already set (${currentSystem})`;
+  }
+  return null;
+}
+
 async function main() {
   if (!shouldRunPostinstall(process.env)) return;
 
   const home = homedir();
   if (!home) return;
 
-  const { getGlobalHooksPath } = await import("../src/git-config.js");
+  const { getGlobalHooksPath, getSystemHooksPath } = await import("../src/git-config.js");
   const { resolveHooksDirectory } = await import("../src/hooks.js");
   const { installManagedHooks } = await import("../src/installer.js");
 
   const hooksDirectory = resolveHooksDirectory(home);
-  const current = await getGlobalHooksPath().catch(() => null);
+  const [current, currentSystem] = await Promise.all([
+    getGlobalHooksPath().catch(() => null),
+    getSystemHooksPath().catch(() => null)
+  ]);
 
-  if (current && current !== hooksDirectory) {
-    // Respect an existing custom global hooks path (e.g. a team setup); don't
-    // take it over during an npm install.
+  const existing = describeExistingHooksPath(current, currentSystem, hooksDirectory);
+  if (existing) {
+    // Respect an existing custom hooks path (e.g. a team setup); don't take
+    // it over during an npm install.
     process.stdout.write(
-      `gforge: a global core.hooksPath is already set (${current}).\n` +
+      `gforge: ${existing}.\n` +
       "        Run `gforge install` if you want GForge to manage it.\n"
     );
     return;

--- a/src/git-config.js
+++ b/src/git-config.js
@@ -18,9 +18,34 @@ export async function getGlobalHooksPath(execFileFn = execFileAsync) {
   }
 }
 
+// System scope (e.g. /etc/gitconfig, or org policy pushed via
+// GIT_CONFIG_SYSTEM) sits BELOW global in git's real precedence order
+// (local > global > system) — so a system-mandated core.hooksPath is never
+// itself in danger of being overridden by a repo or global value, but it IS
+// at risk of being silently *shadowed*: writing a new global value outranks
+// it, even though nothing at the system level was ever touched (issue #41).
+export async function getSystemHooksPath(execFileFn = execFileAsync) {
+  try {
+    const result = await execFileFn("git", ["config", "--system", "--get", "core.hooksPath"]);
+    const value = String(result.stdout ?? "").trim();
+
+    return value || null;
+  } catch (error) {
+    if (error?.code === 1 || error?.code === "1") {
+      // Covers both "key not set" and "no system gitconfig file at all"
+      // (verified directly: git exits 1 for --get in both cases, unlike
+      // --list, which fails differently when the file is entirely absent).
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 // Resolves core.hooksPath the way git actually would in the current directory:
-// a repository-local or system value overrides the global one. Used by verify to
-// warn when a repo-local hooks setup (e.g. Husky, lefthook) shadows GForge.
+// a repository-local value overrides the global one, which in turn overrides
+// a system-level one. Used by verify to warn when a repo-local hooks setup
+// (e.g. Husky, lefthook) shadows GForge.
 export async function getEffectiveHooksPath(execFileFn = execFileAsync) {
   try {
     const result = await execFileFn("git", ["config", "--get", "core.hooksPath"]);
@@ -33,6 +58,21 @@ export async function getEffectiveHooksPath(execFileFn = execFileAsync) {
     }
 
     throw error;
+  }
+}
+
+// The current repository's actual .git directory (verified: exits non-zero,
+// e.g. 128, for any reason it can't be determined — no single exit code
+// covers every case the way config --get's "1" does, so any failure here
+// uniformly means "nothing to check", never something worth surfacing).
+export async function getRepoGitDir(execFileFn = execFileAsync) {
+  try {
+    const result = await execFileFn("git", ["rev-parse", "--git-dir"]);
+    const value = String(result.stdout ?? "").trim();
+
+    return value || null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -6,6 +6,7 @@ import { VERSION } from "./metadata.js";
 import {
   getEffectiveHooksPath,
   getGlobalHooksPath,
+  getRepoGitDir,
   setGlobalHooksPath,
   unsetGlobalHooksPath
 } from "./git-config.js";
@@ -227,6 +228,13 @@ export async function verifyManagedHooks(options = {}) {
       label: "effective-hooks-path",
       detail: `core.hooksPath resolves to ${effectiveHooksPath} here; a repository-local or system override shadows the managed hooks, so GForge will not run in this repository`
     });
+  } else if (effectiveHooksPath === hooksDirectory) {
+    // The mirror-image case: GForge IS what's actually active here, which
+    // means git no longer looks in this repository's own hooks/ directory
+    // at all - a classic hand-written script left there goes silently
+    // dormant, for every hook type, not just pre-commit (issue #41).
+    const classicHook = await checkClassicHookShadowed(execFileFn);
+    if (classicHook) checks.push(classicHook);
   }
 
   checks.push(await checkDirectory(hooksDirectory));
@@ -454,6 +462,33 @@ async function safeGetEffectiveHooksPath(execFileFn) {
   } catch {
     return null;
   }
+}
+
+// A classic hand-written .git/hooks/pre-commit script goes silently dormant
+// once GForge's global core.hooksPath is what actually resolves here — git
+// only ever consults ONE hooksPath location, and it is no longer this
+// repository's own hooks/ directory (issue #41). Nothing to check outside a
+// git repository; never fatal, since the developer may not even have relied
+// on it, but they deserve to know it stopped running.
+async function checkClassicHookShadowed(execFileFn) {
+  const gitDir = await getRepoGitDir(execFileFn);
+  if (!gitDir) return null;
+
+  const classicPath = join(gitDir, "hooks", PRE_COMMIT_FILE_NAME);
+  try {
+    const classicStat = await stat(classicPath);
+    if (!(classicStat.mode & 0o111)) return null; // present but not executable - git would never have run it either
+  } catch {
+    return null;
+  }
+
+  return {
+    status: "WARN",
+    label: "classic-hook-shadowed",
+    detail:
+      `${classicPath} is executable but dormant — GForge's global core.hooksPath means git no longer looks ` +
+      "in this repository's own hooks/ directory, for any hook type, not just pre-commit"
+  };
 }
 
 async function checkDirectory(hooksDirectory) {

--- a/test/git-config.test.js
+++ b/test/git-config.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getRepoGitDir, getSystemHooksPath } from "../src/git-config.js";
+
+test("getSystemHooksPath returns the configured value", async () => {
+  const execFile = async (cmd, args) => {
+    assert.equal(cmd, "git");
+    assert.deepEqual(args, ["config", "--system", "--get", "core.hooksPath"]);
+    return { stdout: "/etc/gforge-org-hooks\n" };
+  };
+
+  assert.equal(await getSystemHooksPath(execFile), "/etc/gforge-org-hooks");
+});
+
+test("getSystemHooksPath returns null when nothing is set at system scope", async () => {
+  const execFile = async () => {
+    const error = new Error("key not found");
+    error.code = 1;
+    throw error;
+  };
+
+  assert.equal(await getSystemHooksPath(execFile), null);
+});
+
+test("getSystemHooksPath returns null when there is no system gitconfig file at all", async () => {
+  // Verified directly against a real git binary: --get exits 1 in this case
+  // too (unlike --list, which fails differently) — same code path as "key
+  // not set", not a special case.
+  const execFile = async () => {
+    const error = new Error("unable to read config file '/etc/gitconfig': No such file or directory");
+    error.code = 1;
+    throw error;
+  };
+
+  assert.equal(await getSystemHooksPath(execFile), null);
+});
+
+test("getSystemHooksPath rethrows a genuinely unexpected error", async () => {
+  const execFile = async () => {
+    const error = new Error("git not found");
+    error.code = "ENOENT";
+    throw error;
+  };
+
+  await assert.rejects(() => getSystemHooksPath(execFile), { code: "ENOENT" });
+});
+
+test("getRepoGitDir returns the resolved directory inside a repository", async () => {
+  const execFile = async (cmd, args) => {
+    assert.equal(cmd, "git");
+    assert.deepEqual(args, ["rev-parse", "--git-dir"]);
+    return { stdout: ".git\n" };
+  };
+
+  assert.equal(await getRepoGitDir(execFile), ".git");
+});
+
+test("getRepoGitDir returns null (never throws) outside a git repository", async () => {
+  const execFile = async () => {
+    const error = new Error("fatal: not a git repository (or any of the parent directories): .git");
+    error.code = 128;
+    throw error;
+  };
+
+  assert.equal(await getRepoGitDir(execFile), null);
+});
+
+test("getRepoGitDir returns null for any other failure too (best-effort, never fatal)", async () => {
+  const execFile = async () => {
+    throw new Error("git not found");
+  };
+
+  assert.equal(await getRepoGitDir(execFile), null);
+});

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -441,6 +441,65 @@ test("verify fails the git-version check on an old git even if hooksPath happens
   assert.equal(hooksPathCheck.status, "PASS");
 });
 
+test("issue #41: verify warns when a classic .git/hooks/pre-commit is dormant under GForge's global path", async () => {
+  const homePath = await createTempHome();
+  const repoGitDir = await createTempHome(); // reused as a stand-in "repo" .git directory
+  await mkdir(join(repoGitDir, "hooks"), { recursive: true });
+  const classicHook = join(repoGitDir, "hooks", "pre-commit");
+  await writeFile(classicHook, "#!/bin/sh\nexit 1\n");
+  await chmod(classicHook, 0o755);
+
+  const hooksDirectory = resolveHooksDirectory(homePath);
+  const git = createGitConfigMock(hooksDirectory, repoGitDir); // GForge already the active hooksPath
+
+  const report = await verifyManagedHooks({ environment: createEnvironment(homePath), execFile: git.execFile });
+
+  const shadowed = report.checks.find((check) => check.label === "classic-hook-shadowed");
+  assert.ok(shadowed, "expected a classic-hook-shadowed check");
+  assert.equal(shadowed.status, "WARN");
+  assert.match(shadowed.detail, /is executable but dormant/);
+  assert.match(shadowed.detail, new RegExp(classicHook.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("issue #41: no warning when there is no classic hook file, it isn't executable, or GForge isn't the active hooksPath", async () => {
+  const homePath = await createTempHome();
+  const hooksDirectory = resolveHooksDirectory(homePath);
+
+  // No classic hook file at all.
+  const emptyRepoDir = await createTempHome();
+  await mkdir(join(emptyRepoDir, "hooks"), { recursive: true });
+  let git = createGitConfigMock(hooksDirectory, emptyRepoDir);
+  let report = await verifyManagedHooks({ environment: createEnvironment(homePath), execFile: git.execFile });
+  assert.equal(report.checks.some((check) => check.label === "classic-hook-shadowed"), false);
+
+  // Classic hook file present but not executable - git would never have run
+  // it either, so it isn't something GForge's install newly broke.
+  const nonExecRepoDir = await createTempHome();
+  await mkdir(join(nonExecRepoDir, "hooks"), { recursive: true });
+  await writeFile(join(nonExecRepoDir, "hooks", "pre-commit"), "#!/bin/sh\nexit 1\n");
+  git = createGitConfigMock(hooksDirectory, nonExecRepoDir);
+  report = await verifyManagedHooks({ environment: createEnvironment(homePath), execFile: git.execFile });
+  assert.equal(report.checks.some((check) => check.label === "classic-hook-shadowed"), false);
+
+  // A classic hook exists and GForge is installed, but something else (e.g.
+  // Husky) is the hooksPath actually in effect here - already surfaced via
+  // effective-hooks-path, so this check does not also fire. A dedicated mock
+  // (not the one above) so "config --get" and "rev-parse --git-dir" cannot
+  // accidentally resolve against the wrong scenario's directories.
+  const shadowedByOtherDir = await createTempHome();
+  await mkdir(join(shadowedByOtherDir, "hooks"), { recursive: true });
+  const otherClassicHook = join(shadowedByOtherDir, "hooks", "pre-commit");
+  await writeFile(otherClassicHook, "#!/bin/sh\nexit 1\n");
+  await chmod(otherClassicHook, 0o755);
+  const otherGit = createGitConfigMock(hooksDirectory, shadowedByOtherDir);
+  const execFile = async (command, args) => {
+    if (args.join(" ") === "config --get core.hooksPath") return { stdout: "/opt/husky/hooks\n" };
+    return otherGit.execFile(command, args);
+  };
+  report = await verifyManagedHooks({ environment: createEnvironment(homePath), execFile });
+  assert.equal(report.checks.some((check) => check.label === "classic-hook-shadowed"), false);
+});
+
 async function createTempHome() {
   return mkdtemp(join(tmpdir(), "gforge-test-"));
 }
@@ -454,7 +513,11 @@ function createEnvironment(homePath) {
   };
 }
 
-function createGitConfigMock(initialHooksPath = null) {
+// gitDir, when provided, simulates running inside a repository whose
+// `git rev-parse --git-dir` resolves to that path; the default (null)
+// simulates not being inside a git repository at all (rev-parse fails),
+// matching where every pre-existing test in this file already runs from.
+function createGitConfigMock(initialHooksPath = null, gitDir = null) {
   let hooksPath = initialHooksPath;
 
   return {
@@ -486,6 +549,15 @@ function createGitConfigMock(initialHooksPath = null) {
       if (args.join(" ") === "config --global --unset core.hooksPath") {
         hooksPath = null;
         return { stdout: "" };
+      }
+
+      if (args.join(" ") === "rev-parse --git-dir") {
+        if (!gitDir) {
+          const error = new Error("fatal: not a git repository (or any of the parent directories): .git");
+          error.code = 128;
+          throw error;
+        }
+        return { stdout: `${gitDir}\n` };
       }
 
       throw new Error(`Unexpected git args: ${args.join(" ")}`);

--- a/test/postinstall.test.js
+++ b/test/postinstall.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { shouldRunPostinstall } from "../scripts/postinstall.js";
+import { describeExistingHooksPath, shouldRunPostinstall } from "../scripts/postinstall.js";
 
 test("issue #38: a plain local install (no -g) never touches global git config", () => {
   // This is the exact bug: gforge as a local project dependency, or pulled in
@@ -28,4 +28,30 @@ test("only the literal npm-set string \"true\" counts as global (fails closed)",
   // not be treated as a global install.
   assert.equal(shouldRunPostinstall({ npm_config_global: "1" }), false);
   assert.equal(shouldRunPostinstall({ npm_config_global: "TRUE" }), false);
+});
+
+test("issue #41: describeExistingHooksPath respects an existing global value", () => {
+  const existing = describeExistingHooksPath("/opt/husky/hooks", null, "/home/u/.gforge/hooks");
+  assert.match(existing, /global core\.hooksPath is already set \(\/opt\/husky\/hooks\)/);
+});
+
+test("issue #41: describeExistingHooksPath also respects a system-level value with no global set", () => {
+  // The actual bug: nothing at global scope, so the old check saw "nothing
+  // configured" and proceeded - but writing a global value now would
+  // outrank and silently shadow the system-mandated one.
+  const existing = describeExistingHooksPath(null, "/etc/gforge-org-hooks", "/home/u/.gforge/hooks");
+  assert.match(existing, /system-level core\.hooksPath is already set \(\/etc\/gforge-org-hooks\)/);
+});
+
+test("issue #41: a global value takes precedence over a system value in the message (matches git's real precedence)", () => {
+  const existing = describeExistingHooksPath("/opt/husky/hooks", "/etc/gforge-org-hooks", "/home/u/.gforge/hooks");
+  assert.match(existing, /global core\.hooksPath/);
+});
+
+test("issue #41: proceeds when nothing is configured, or GForge's own path is already active at either scope", () => {
+  assert.equal(describeExistingHooksPath(null, null, "/home/u/.gforge/hooks"), null);
+  assert.equal(describeExistingHooksPath("/home/u/.gforge/hooks", null, "/home/u/.gforge/hooks"), null);
+  // GForge's own path already active at system scope too must not block a
+  // (re-)install that would just set the same value at global scope.
+  assert.equal(describeExistingHooksPath(null, "/home/u/.gforge/hooks", "/home/u/.gforge/hooks"), null);
 });


### PR DESCRIPTION
Two related gaps in how GForge's global core.hooksPath install could silently kill an existing hook setup, neither caught by the existing "respect an already-configured hooksPath" check:

1. That check only ever looked at GLOBAL scope. Git's real precedence is local > global > system, so a system-mandated core.hooksPath (e.g. pushed org-wide via GIT_CONFIG_SYSTEM) was invisible to it - nothing at global scope meant "safe to proceed", and writing a new global value then silently outranked and shadowed the system one, even though GForge never touched the system file itself. This directly contradicted the README's claim that GForge does not override an existing core.hooksPath. postinstall now also checks system scope (getSystemHooksPath) before writing anything.

2. A classic, hand-written .git/hooks/pre-commit script isn't a core.hooksPath value at all, so there was never anything for that check to detect in the first place - git just silently stops looking in a repository's own hooks/ directory once GForge's global path is active, for every hook type, not just pre-commit. There is no way to preserve that automatically (git only ever consults one hooksPath location), so `gforge verify` now detects and reports it instead: a new classic-hook-shadowed WARN fires when a repository has an executable classic pre-commit hook that's gone dormant under GForge's active path.

Verified both against a real (unmocked) git binary and a real temp repository, not just the unit-test mocks: getSystemHooksPath against an actual GIT_CONFIG_SYSTEM file, and checkClassicHookShadowed's full warning against a real .git/hooks/pre-commit made dormant by an actual global core.hooksPath override.

git-config.js had zero direct test coverage before this; added test/git-config.test.js for the two new exports.

Updated the README section this issue quoted to describe both the now-covered system-scope case and the still-uncovered (but now detected) classic-hook case precisely, rather than the previous overstated blanket claim.

Fixes #41