### PR TITLE
Filter weak dotenv values and enforce word boundaries in secret cross…

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -736,11 +736,25 @@ const DOTENV_VALUE_STOPLIST = new RegExp(
   "i"
 );
 
+// A weak/common dev-default value ("password") sitting behind a
+// credential-shaped key name used to be trusted unconditionally — but it
+// gets cross-referenced against every staged file as an exact string, so a
+// short, common word is exactly the value most likely to also appear,
+// completely unrelated, as plain text elsewhere (a `type="password"` HTML
+// attribute) (issue #43). Real generated secrets/tokens run far longer than
+// this in practice, so require some real length even once the key matches.
+const DOTENV_MIN_KEYED_VALUE_LENGTH = 10;
+// A CSS-shaped hex color (#fff, #a1b2c3, #a1b2c3d4) — a very common `.env`
+// theme/branding value, and its short, fixed-alphabet shape is exactly what
+// makes it likely to coincidentally match unrelated code (issue #43).
+const DOTENV_HEX_COLOR_RE = /^#?[0-9a-fA-F]{3,4}$|^#?[0-9a-fA-F]{6}$|^#?[0-9a-fA-F]{8}$/;
+
 function looksLikeDotenvSecret(key, value) {
   if (value.length < 6) return false;
   if (DOTENV_VALUE_STOPLIST.test(value)) return false;
   if (/^\d+$/.test(value)) return false; // ports, ids
-  if (DOTENV_KEY_IS_SECRET.test(key)) return true;
+  if (DOTENV_HEX_COLOR_RE.test(value)) return false;
+  if (DOTENV_KEY_IS_SECRET.test(key)) return value.length >= DOTENV_MIN_KEYED_VALUE_LENGTH;
   // Otherwise only treat long, random-looking values as secrets.
   return value.length >= 12 && /[A-Za-z]/.test(value) && /[0-9]/.test(value);
 }
@@ -845,10 +859,27 @@ export function describeDotenvSources(root = repoRoot()) {
   };
 }
 
-function lineOfSubstring(content, needle) {
-  const index = content.indexOf(needle);
-  if (index === -1) return 0;
-  return content.slice(0, index).split(/\r?\n/).length;
+// Finds the first occurrence of `needle` that isn't embedded inside a larger
+// run of identifier characters on either side — a short secret value must
+// not match as a coincidental fragment of an unrelated, longer word/token
+// (issue #43: e.g. a secret "pass" must not match inside "passenger"). A
+// needle whose own edge isn't itself an identifier character (starts or ends
+// with a symbol) has no boundary to violate on that side, so any occurrence
+// there already counts, same as a plain substring match would.
+function isIdentifierChar(ch) {
+  return ch !== undefined && /[A-Za-z0-9_]/.test(ch);
+}
+function findWordBoundaryIndex(content, needle) {
+  const needleStartsWord = isIdentifierChar(needle[0]);
+  const needleEndsWord = isIdentifierChar(needle[needle.length - 1]);
+  let index = content.indexOf(needle);
+  while (index !== -1) {
+    const leftOk = !needleStartsWord || !isIdentifierChar(content[index - 1]);
+    const rightOk = !needleEndsWord || !isIdentifierChar(content[index + needle.length]);
+    if (leftOk && rightOk) return index;
+    index = content.indexOf(needle, index + 1);
+  }
+  return -1;
 }
 
 // Optional turbo layer: if the gitleaks binary is installed, run it over the
@@ -892,10 +923,11 @@ export function scanStaged(options = {}) {
 
     // Highest-precision check: a real secret value from .env hardcoded here.
     for (const secret of dotenvSecrets) {
-      if (content.includes(secret)) {
+      const index = findWordBoundaryIndex(content, secret);
+      if (index !== -1) {
         findings.push({
           file,
-          line: lineOfSubstring(content, secret),
+          line: content.slice(0, index).split(/\r?\n/).length,
           ruleId: "hardcoded-dotenv-secret",
           description: "a secret value from a .env file is hardcoded here"
         });

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -495,6 +495,78 @@ test("cross-references staged code against .env secret values", () => {
   assert.equal(clean.findings.length, 0);
 });
 
+test("issue #43: a weak/common word behind a credential-shaped key is not extracted as a secret", () => {
+  // Real-world false positive: a dev-default value like "password" is
+  // exactly the kind of text that also shows up, completely unrelated, in
+  // ordinary code (an HTML type="password" attribute). The extracted list
+  // (not a hand-picked dotenvSecrets array, which would bypass extraction
+  // filtering entirely) is what a real commit is actually checked against.
+  const root = makeTree({ ".env": "DEFAULT_PASSWORD=password\n" });
+  const secrets = loadDotenvSecrets(root);
+  assert.equal(secrets.includes("password"), false);
+
+  const leak = scanStaged({
+    ...opts, allowlist: [], dotenvSecrets: secrets,
+    files: ["LoginForm.tsx"], read: () => '<input type="password" autoComplete="current-password" />'
+  });
+  assert.equal(leak.findings.length, 0);
+});
+
+test("issue #43: a CSS-shaped hex color is not extracted as a secret", () => {
+  // Another real-world false positive: a theme/branding color value in .env,
+  // coincidentally matching an unrelated color literal elsewhere.
+  for (const envContent of ["THEME_ACCENT_KEY=3a86ff\n", "BRAND_API_KEY=#fff\n", "SECRET_COLOR_TOKEN=a1b2c3d4\n"]) {
+    const root = makeTree({ ".env": envContent });
+    assert.deepEqual(loadDotenvSecrets(root), [], envContent);
+  }
+
+  const root = makeTree({ ".env": "THEME_ACCENT_KEY=3a86ff\n" });
+  const secrets = loadDotenvSecrets(root);
+  const leak = scanStaged({
+    ...opts, allowlist: [], dotenvSecrets: secrets,
+    files: ["theme.tsx"], read: () => "export const PRIMARY = '#3a86ff';"
+  });
+  assert.equal(leak.findings.length, 0);
+});
+
+test("issue #43: a genuinely strong secret behind a credential-shaped key is still caught", () => {
+  const root = makeTree({ ".env": "REAL_API_TOKEN=aX9kQm2pLw8vRt4zNcQ7\n" });
+  const secrets = loadDotenvSecrets(root);
+  assert.ok(secrets.includes("aX9kQm2pLw8vRt4zNcQ7"));
+
+  const leak = scanStaged({
+    ...opts, allowlist: [], dotenvSecrets: secrets,
+    files: ["leak.js"], read: () => 'const t = "aX9kQm2pLw8vRt4zNcQ7";'
+  });
+  assert.ok(leak.findings.some((f) => f.ruleId === "hardcoded-dotenv-secret"));
+});
+
+test("issue #43: the cross-reference respects word boundaries, not a raw substring match", () => {
+  const secret = "longenoughsecret1";
+
+  // Embedded as a fragment inside a longer, unrelated identifier: not a match.
+  const embedded = scanStaged({
+    ...opts, allowlist: [], dotenvSecrets: [secret],
+    files: ["a.js"], read: () => 'const x = "prefixlongenoughsecret1suffix";'
+  });
+  assert.equal(embedded.findings.length, 0);
+
+  // The same value as a standalone token is still caught.
+  const standalone = scanStaged({
+    ...opts, allowlist: [], dotenvSecrets: [secret],
+    files: ["a.js"], read: () => `const x = "${secret}";`
+  });
+  assert.ok(standalone.findings.some((f) => f.ruleId === "hardcoded-dotenv-secret"));
+
+  // A value bordered by non-identifier punctuation (not itself embedded in a
+  // larger word) still matches, same as a plain substring check would.
+  const punctuated = scanStaged({
+    ...opts, allowlist: [], dotenvSecrets: [secret],
+    files: ["a.js"], read: () => `Authorization: Bearer ${secret}!`
+  });
+  assert.ok(punctuated.findings.some((f) => f.ruleId === "hardcoded-dotenv-secret"));
+});
+
 test("cross-references .env files in package subdirectories, not just the repo root", () => {
   // The monorepo layout from issue #26: no root .env at all, one per package.
   const root = makeTree({


### PR DESCRIPTION
…-reference

Real-world false positives: a dev-default value like "password" behind a credential-shaped key, or a CSS hex color like "#3a86ff" in a theme .env variable, were trusted unconditionally and then cross-referenced as an exact substring against every staged file — matching unrelated code (an HTML type="password" attribute, an unrelated color literal). Now requires real length even for keyed values, excludes hex-color-shaped values, and the cross-reference itself matches on word boundaries instead of raw substring so a secret can no longer match as a coincidental fragment inside a longer word.

Fixes #43