### PR TITLE
Fail closed when reading staged content for a scan fails unexpectedly

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -665,11 +665,23 @@ export function decodeBlob(buf) {
   return buf.toString("latin1");
 }
 
+// `git show :path` exits with a normal (non-zero) process status for the two
+// genuinely expected failures — the path is not staged, or it is a
+// submodule/gitlink entry — so `error.status` is a real exit code in both
+// cases (verified empirically: 128 for each). Anything else — the process
+// killed by a signal (maxBuffer exceeded leaves `status: null`), a spawn
+// failure (missing binary, permissions) — is a real read failure, not
+// "nothing to scan here", and must not be treated the same way (issue #44).
+export function isExpectedGitReadFailure(error) {
+  return typeof error?.status === "number";
+}
+
 function stagedContent(filePath) {
   try {
     return decodeBlob(git(["show", `:${filePath}`]));
-  } catch {
-    return null; // submodule/gitlink or unreadable; nothing to scan.
+  } catch (error) {
+    if (isExpectedGitReadFailure(error)) return null; // submodule/gitlink or not staged.
+    throw error; // genuine read failure: fail closed rather than scan nothing.
   }
 }
 

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -12,6 +12,7 @@ import {
   entropyCandidates,
   formatReport,
   isDotenvFile,
+  isExpectedGitReadFailure,
   isHeuristicExemptPath,
   isEnvTemplate,
   loadDotenvSecrets,
@@ -649,6 +650,26 @@ test("does not flag trivial non-secret values (PASS=123)", () => {
 test("shannon entropy scores random strings above plain text", () => {
   assert.ok(shannonEntropy("Zx9Kq2mVbN7pLwR4tYaSdFgHjKl") > 4.2);
   assert.ok(shannonEntropy("aaaaaaaaaaaaaaaaaaaa") < 1);
+});
+
+test("issue #44: a normal git-show exit (not staged / submodule) is the only case treated as nothing-to-scan", () => {
+  // Empirically verified against real git: `git show :path` for a path that
+  // is not staged, and for a submodule/gitlink entry, both exit with a
+  // normal (non-zero) process status of 128 - no signal, no spawn-level
+  // error code.
+  assert.equal(isExpectedGitReadFailure({ status: 128 }), true);
+  assert.equal(isExpectedGitReadFailure({ status: 1 }), true);
+});
+
+test("issue #44: a genuine read failure (buffer overflow, spawn failure) is not mistaken for nothing-to-scan", () => {
+  // Empirically verified: when execFileSync's maxBuffer is exceeded, the
+  // child is killed by a signal and the thrown error has `status: null`
+  // with `code: 'ENOBUFS'` - not a normal process exit at all.
+  assert.equal(isExpectedGitReadFailure({ status: null, code: "ENOBUFS", signal: "SIGTERM" }), false);
+  // A spawn-level failure (missing binary, permissions) never reaches a
+  // process exit either.
+  assert.equal(isExpectedGitReadFailure({ status: undefined, code: "ENOENT" }), false);
+  assert.equal(isExpectedGitReadFailure(new Error("boom")), false);
 });
 
 // Materializes { "relative/path": "content" } under a fresh temp directory and


### PR DESCRIPTION
`stagedContent()` swallowed every `git show` failure into "nothing to scan here" — the correct outcome for the two genuinely expected cases (path not staged, submodule/gitlink entry), but also for a real read failure such as the fixed 512MB maxBuffer being exceeded on an oversized staged file. In that case the tool silently scanned zero findings and reported success, giving any secret in a large enough file a free pass with no warning.

Verified empirically against real git: both expected cases exit with a normal, non-zero process status (128). A maxBuffer overflow instead kills the process by signal (status: null, code: ENOBUFS), and a spawn-level failure never produces a process exit status at all. isExpectedGitReadFailure() uses that distinction — anything that isn't a normal process exit now rethrows and blocks the commit, consistent with the fail-closed handling already in place for other scanner startup failures.

Fixes #44