### PR TITLE
Abort uninstall instead of deleting hooks when core.hooksPath can't b…

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -138,7 +138,29 @@ export async function uninstallManagedHooks(options = {}) {
   const hooksDirectory = resolveHooksDirectory(homePath);
   const statePath = resolveStatePath(homePath);
   const { state, corrupt } = await readStateFile(statePath);
-  const configuredHooksPath = await safeGetGlobalHooksPath(execFileFn);
+
+  // getGlobalHooksPath() already distinguishes "genuinely not configured"
+  // (returns null) from an unexpected read failure (throws) - do NOT flatten
+  // that back into null here the way the read-only verify path safely can.
+  // If the read fails for any transient reason while the real gitconfig
+  // value is still core.hooksPath=<managed dir>, treating it as "not
+  // configured" would skip the restore/unset below and then still delete the
+  // managed hook files - leaving global core.hooksPath silently pointed at a
+  // now-deleted directory, disabling every git hook on the machine (issue #40).
+  let configuredHooksPath;
+  try {
+    configuredHooksPath = await getGlobalHooksPath(execFileFn);
+  } catch (error) {
+    return {
+      ok: false,
+      command: "uninstall",
+      exitCode: 1,
+      hooksDirectory,
+      messages: [
+        `Could not read the current global core.hooksPath (${error?.message ?? error}); aborting without changing anything, to avoid leaving a stale hooksPath pointed at deleted files`
+      ]
+    };
+  }
   const messages = [];
 
   if (configuredHooksPath === hooksDirectory) {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -220,6 +220,41 @@ test("uninstall does not overwrite unrelated hooks path", async () => {
   assert.match(result.messages.join("\n"), /Skipped core\.hooksPath restore/);
 });
 
+test("issue #40: uninstall aborts without deleting anything when reading core.hooksPath fails transiently", async () => {
+  const homePath = await createTempHome();
+  const git = createGitConfigMock();
+  const hooksDirectory = resolveHooksDirectory(homePath);
+
+  await installManagedHooks({
+    environment: createEnvironment(homePath),
+    execFile: git.execFile
+  });
+
+  // The real gitconfig still has core.hooksPath = the managed directory -
+  // only this one read of it fails, transiently (e.g. a momentary lock/IO
+  // error), which must not be mistaken for "not configured".
+  const flakyExecFile = async (command, args) => {
+    if (args.join(" ") === "config --global --get core.hooksPath") {
+      const error = new Error("could not lock config file .gitconfig: File exists");
+      error.code = "EBUSY";
+      throw error;
+    }
+    return git.execFile(command, args);
+  };
+
+  const result = await uninstallManagedHooks({
+    environment: createEnvironment(homePath),
+    execFile: flakyExecFile
+  });
+
+  assert.equal(result.ok, false);
+  // Nothing was touched: the managed hook file is still on disk, the
+  // gitconfig value is untouched, and it still points at that same
+  // directory - so no commit-blocking hook silently goes dark machine-wide.
+  await assert.doesNotReject(stat(join(hooksDirectory, "pre-commit")));
+  assert.equal(git.hooksPath(), hooksDirectory);
+});
+
 test("uninstall leaves non-empty GForge directories in place", async () => {
   const homePath = await createTempHome();
   const git = createGitConfigMock();
@@ -353,7 +388,13 @@ test("verify warns when a repo-local hooks path shadows the managed hooks", asyn
   assert.match(warning.detail, /\.husky/);
 });
 
-test("uninstall still removes files when the global gitconfig cannot be read", async () => {
+test("issue #40: uninstall aborts, and removes nothing, when the global gitconfig cannot be read", async () => {
+  // Previously this uninstall would still remove the managed hook/state files
+  // and report success - treating an unreadable gitconfig exactly like "no
+  // hooksPath configured". If the real config value was still the managed
+  // directory, that left global core.hooksPath silently pointed at deleted
+  // files: every git hook on the machine, of any kind, goes dark with no
+  // warning. The read failure must abort instead of being flattened away.
   const homePath = await createTempHome();
   const git = createGitConfigMock();
 
@@ -380,9 +421,9 @@ test("uninstall still removes files when the global gitconfig cannot be read", a
     execFile
   });
 
-  assert.equal(result.ok, true);
-  await assert.rejects(stat(join(resolveHooksDirectory(homePath), "pre-commit")), { code: "ENOENT" });
-  await assert.rejects(stat(resolveStatePath(homePath)), { code: "ENOENT" });
+  assert.equal(result.ok, false);
+  await assert.doesNotReject(stat(join(resolveHooksDirectory(homePath), "pre-commit")));
+  await assert.doesNotReject(stat(resolveStatePath(homePath)));
 });
 
 test("refuses to install on a git older than 2.9 (no core.hooksPath support)", async () => {


### PR DESCRIPTION
…e read

uninstallManagedHooks() read the current global core.hooksPath through a wrapper that swallowed every failure into null, identical to "not configured". If that read failed only transiently (a momentary lock/IO error) while the real gitconfig value was still GForge's managed directory, uninstall took the "nothing to restore" branch, deleted the managed hook/state files anyway, and reported success — leaving global core.hooksPath pointed at a now-deleted directory. From that point every git hook on the machine, of any kind, silently stops running, with no warning that anything went wrong.

getGlobalHooksPath() in git-config.js already distinguishes "genuinely not configured" (exit code 1, returns null) from any other read failure (rethrows) — the bug was flattening that distinction back to null right before using it. Uninstall now aborts immediately on an unexpected read failure, before touching any file, instead of proceeding as if nothing was configured.

Fixes #40