### PR TITLE
Give route segments their own minimum-check length so real route word…

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -210,6 +210,19 @@ const ROUTE_SEGMENT_MAX_LENGTH = 20; // real route words; secrets run longer
 // Below IDENTIFIER_MIN_VOWEL_RATIO because compound route words are vowel-poor
 // ("changepassword" is 0.286), while random lowercase letters sit near 0.19.
 const ROUTE_MIN_VOWEL_RATIO = 0.25;
+// The route layer needs its own floor rather than NAME_SEGMENT_MIN_CHECK_LENGTH
+// (8), which was picked for the entropy layer's path segments. Real route
+// vocabulary is vowel-poorer than the ratio admits at short lengths —
+// "graphqlws" is 0.111, "transcript" and "postgresql" 0.200, "playlists" and
+// "callbacks" 0.222 — so a 475-word route corpus lost 13 words to the gate.
+// Lowering the ratio is the wrong lever: over random lowercase segments placed
+// after a route prefix, 0.20 drops detection at every length (66% -> 45% at 20
+// characters) and STILL rejects "graphqlws"; so does a minimum-vowel-count rule.
+// Raising the floor to 12 clears 12 of the 13 words and leaves detection for
+// 12+ character segments exactly where it was (58-77%). What it gives up is an
+// all-lowercase 8-11 character secret inside a route template, where the ratio
+// was near a coin flip (52-76%) anyway (issue #68).
+const ROUTE_SEGMENT_MIN_CHECK_LENGTH = 12;
 
 // A route segment is a WORD, not a blob. Lowercase is not enough on its own: hex
 // beginning a-f ("a3f9b2c8…") and an all-lowercase token are lowercase too, and
@@ -222,7 +235,7 @@ function looksLikeRouteSegment(segment) {
   if (word.length > ROUTE_SEGMENT_MAX_LENGTH) return false;
   const digits = (word.match(/[0-9]/g) || []).length;
   if (digits > PATH_SEGMENT_MAX_DIGITS && digits / word.length > PATH_SEGMENT_MAX_DIGIT_RATIO) return false;
-  if (word.length < NAME_SEGMENT_MIN_CHECK_LENGTH) return true; // api, v1, uuid
+  if (word.length < ROUTE_SEGMENT_MIN_CHECK_LENGTH) return true; // api, v1, graphqlws
   const letters = word.replace(/[^a-z]/g, "");
   return letters.length > 0 && ratioOf(letters, /[aeiou]/g) >= ROUTE_MIN_VOWEL_RATIO;
 }

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -387,6 +387,39 @@ test("issue #37: appending the literal secret to a credential-keyword identifier
   );
 });
 
+test("issue #68: vowel-poor real route words are still route templates", () => {
+  // The 25% vowel ratio is an English-word bar, and real route vocabulary sits
+  // under it: "graphqlws" (graphql-ws, a real library) carries 1 vowel in 9
+  // letters, "transcript" and "postgresql" 2 in 10, "playlists" 2 in 9.
+  assert.equal(ruleIds("routes.ts", 'export const WS_TOKEN = "api/:version/graphqlws";').length, 0);
+  assert.equal(ruleIds("routes.ts", 'export const KEY = "media/:id/transcript";').length, 0);
+  assert.equal(ruleIds("routes.ts", 'export const TOKEN = "users/:id/playlists";').length, 0);
+  assert.equal(ruleIds("routes.ts", 'export const AUTH = "webhooks/:id/callbacks";').length, 0);
+  assert.equal(ruleIds("routes.ts", 'export const SECRET = "db/:name/postgresql";').length, 0);
+});
+
+test("issue #68: a route prefix still does not launder a real secret", () => {
+  // The vowel ratio is unchanged for segments long enough to hold a credential,
+  // so raising the short-segment floor costs no detection at 12+ characters.
+  assert.ok(
+    ruleIds("r.ts", 'const token = "api/:version/qwrtplkjhgfdsazx";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  // Exactly at the new floor: 12 characters is still checked, and 0 vowels fails.
+  assert.ok(
+    ruleIds("r.ts", 'const token = "api/:version/zxcvbnmlkjhg";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  // Mixed case, hex and digit-heavy shapes never depended on the vowel ratio.
+  assert.ok(
+    ruleIds("r.ts", 'const token = "api/:version/aX9kQm2pLw8vRt4zNc";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  assert.ok(
+    ruleIds("r.ts", 'const token = "api/:version/a3f9b2c8d1e4f7a2b9c3d8e1f4a7b2c9";').includes(GENERIC_SECRET_RULE_ID)
+  );
+  assert.ok(
+    ruleIds("r.ts", 'const token = "api/:version/p4ssw0rd1234";').includes(GENERIC_SECRET_RULE_ID)
+  );
+});
+
 test("inline gforge:allow suppresses a line", () => {
   assert.equal(ruleIds("a", "DB_PASS=psspl@443e # gforge:allow").length, 0);
   assert.equal(ruleIds("a", "DB_PASS=psspl@443e // gitleaks:allow").length, 0);


### PR DESCRIPTION
…s pass

The route-template exemption applied its 25% vowel-ratio gate to every segment of 8 characters or more, borrowing NAME_SEGMENT_MIN_CHECK_LENGTH from the entropy layer's path segments. That bar is an English-word bar, and real route vocabulary sits under it: "graphqlws" (graphql-ws, a real library) carries 1 vowel in 9 letters, "transcript" and "postgresql" 2 in 10, "playlists" and "callbacks" 2 in 9. Over a 475-word corpus of real route segments, 13 were rejected and reported as hardcoded credentials.

Lowering the ratio is the wrong lever, and both directions were measured over random lowercase segments placed after a route prefix: 0.20 drops detection at every length (66% -> 45% at 20 characters) and still rejects "graphqlws" at 0.111, and a minimum-vowel-count rule does not clear it either. Raising the floor to 12 clears 12 of the 13 words and leaves the ratio -- and detection for 12+ character segments, 58-77% -- exactly as it was. Corpus false positives drop from 13/474 to 1/474.

What it gives up: an all-lowercase 8-11 character secret sitting inside a /:param route template is no longer flagged. The ratio was near a coin flip there (52-76%) while costing 12 real route words, and a secret of that shape and length is both weak and unusual. "strengthscore" (0.231, 13 characters) stays a known false positive; clearing it would mean a 0.23 ratio, which costs detection at length 13 (77% -> 53%) for one uncommon word.

Pre-existing and independent of #45: reproduces on master with and without the consonant-run change.

Fixes #68