### PR TITLE
Fail gforge verify when a check says scanning is not active

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -246,6 +246,12 @@ export async function verifyManagedHooks(options = {}) {
   const effectiveHooksPath = await safeGetEffectiveHooksPath(execFileFn);
   if (effectiveHooksPath && effectiveHooksPath !== hooksDirectory) {
     checks.push({
+      // Blocking: this is not advisory. Scanning is entirely inactive here, so
+      // `gforge verify` must not report success — a CI gate built on its exit
+      // code would otherwise treat an unprotected repository as healthy
+      // (issue #42). Contrast with classic-hook-shadowed below, which warns
+      // that the user's OWN legacy hook is dormant while GForge itself runs.
+      blocking: true,
       status: "WARN",
       label: "effective-hooks-path",
       detail: `core.hooksPath resolves to ${effectiveHooksPath} here; a repository-local or system override shadows the managed hooks, so GForge will not run in this repository`

--- a/src/verify.js
+++ b/src/verify.js
@@ -28,9 +28,22 @@ export function createVerificationReport(environment, managedHooksReport = null,
     ...dotenvChecks(dotenvReport)
   ];
 
+  // A WARN normally means "worth knowing, still protected" — an unsupported
+  // shell, or one scanner layer being inactive while the others run. But a
+  // check may also mark itself `blocking`, meaning scanning is not active at
+  // all. Those must fail the exit code: `gforge verify && deploy` previously
+  // passed in a repository whose own core.hooksPath shadows the managed hooks,
+  // where the WARN's own text says GForge will not run (issue #42).
+  //
+  // Deliberately keyed off an explicit flag rather than "any WARN": failing on
+  // every WARN would break CI for repositories that simply have no .env file,
+  // which is not a protection gap.
+  const blocking = allChecks.filter((check) => check.blocking);
+
   return {
     checks: allChecks,
-    exitCode: allChecks.some((check) => check.status === "FAIL") ? 1 : 0
+    blocking,
+    exitCode: allChecks.some((check) => check.status === "FAIL") || blocking.length > 0 ? 1 : 0
   };
 }
 
@@ -72,6 +85,15 @@ export function formatVerificationReport(report) {
 
   for (const check of report.checks) {
     lines.push(`${check.status} ${check.label}: ${check.detail}`);
+  }
+
+  // Without this, a non-zero exit driven by a WARN-status check reads as
+  // inexplicable: every line says PASS or WARN, yet the command failed.
+  if (report.blocking?.length) {
+    lines.push("");
+    lines.push(
+      `Not protected: ${report.blocking.map((check) => check.label).join(", ")} — secret scanning is not active here, so verification failed.`
+    );
   }
 
   return `${lines.join("\n")}\n`;

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -386,6 +386,10 @@ test("verify warns when a repo-local hooks path shadows the managed hooks", asyn
   assert.ok(warning, "expected an effective-hooks-path check");
   assert.equal(warning.status, "WARN");
   assert.match(warning.detail, /\.husky/);
+  // issue #42: this check says GForge will not run here, so it must be marked
+  // blocking - that flag is what makes `gforge verify` exit non-zero instead
+  // of reporting an unprotected repository as healthy.
+  assert.equal(warning.blocking, true);
 });
 
 test("issue #40: uninstall aborts, and removes nothing, when the global gitconfig cannot be read", async () => {

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -74,6 +74,78 @@ test("formats warnings without failing verification", () => {
   assert.match(formatVerificationReport(report), /WARN shell: not detected/);
 });
 
+test("issue #42: a blocking check fails the exit code even though its status is WARN", () => {
+  // The reported gap: `gforge verify && deploy` passed in a repository whose
+  // own core.hooksPath shadows the managed hooks - the WARN's own text says
+  // GForge will not run there, so a CI gate was treating a completely
+  // unprotected repository as verified/healthy.
+  const report = createVerificationReport(healthyEnvironment(), {
+    checks: [
+      { status: "PASS", label: "hooks-path", detail: "core.hooksPath is /home/example/.gforge/hooks" },
+      {
+        blocking: true,
+        status: "WARN",
+        label: "effective-hooks-path",
+        detail: "core.hooksPath resolves to /repo/.husky/_ here; ... GForge will not run in this repository"
+      }
+    ]
+  });
+
+  assert.equal(report.exitCode, 1);
+  // The reason is stated, so a non-zero exit is not inexplicable when every
+  // printed line reads PASS or WARN.
+  const output = formatVerificationReport(report);
+  assert.match(output, /Not protected: effective-hooks-path/);
+  assert.match(output, /scanning is not active/);
+});
+
+test("issue #42: informational WARNs still pass, so CI does not break on a missing .env", () => {
+  // The fix keys off an explicit `blocking` flag rather than "any WARN".
+  // Failing on every WARN would fail verification for repositories that simply
+  // have no .env file, or whose shell is unrecognised - neither is a
+  // protection gap, and both are common.
+  const noEnvFile = createVerificationReport(healthyEnvironment(), null, {
+    inRepo: true,
+    root: "/repo",
+    files: [],
+    secretCount: 0
+  });
+  assert.equal(noEnvFile.checks.some((check) => check.status === "WARN"), true);
+  assert.equal(noEnvFile.exitCode, 0);
+
+  const noSecrets = createVerificationReport(healthyEnvironment(), null, {
+    inRepo: true,
+    root: "/repo",
+    files: [".env"],
+    secretCount: 0
+  });
+  assert.equal(noSecrets.exitCode, 0);
+
+  // A classic hand-written hook going dormant means the user's OWN hook will
+  // not run - GForge itself is active, so this must not fail verification.
+  const classicDormant = createVerificationReport(healthyEnvironment(), {
+    checks: [
+      { status: "PASS", label: "hooks-path", detail: "configured" },
+      { status: "WARN", label: "classic-hook-shadowed", detail: "/r/.git/hooks/pre-commit is executable but dormant" }
+    ]
+  });
+  assert.equal(classicDormant.exitCode, 0);
+  // No "Not protected" banner when nothing is actually blocking.
+  assert.equal(/Not protected/.test(formatVerificationReport(classicDormant)), false);
+});
+
+test("issue #42: a FAIL still fails, and combines with blocking checks", () => {
+  const report = createVerificationReport({
+    platform: { name: "linux", arch: "x64", supported: true },
+    home: { path: "/home/example", present: true },
+    shell: { path: "/bin/bash", name: "bash", supported: true },
+    git: { available: false, rawVersion: null }
+  });
+
+  assert.equal(report.exitCode, 1);
+  assert.deepEqual(report.blocking, []);
+});
+
 function healthyEnvironment() {
   return {
     platform: { name: "linux", arch: "x64", supported: true },


### PR DESCRIPTION
verify computed its exit code from FAIL statuses only, so a WARN could never fail it. That included the one case whose own message reads "GForge will not run in this repository" — a repository-local or system core.hooksPath shadowing the managed hooks. `gforge verify && deploy` therefore passed green in a repository where secret scanning was entirely inactive, which defeats the exact mechanism a CI gate would use to catch that state.

Checks can now mark themselves `blocking`, and the exit code fails on FAIL or on any blocking check. Deliberately keyed off an explicit flag rather than "any WARN": failing on every WARN would fail verification for repositories that simply have no .env file, or whose shell is unrecognised, neither of which is a protection gap. Of the WARNs in the tree exactly one is blocking — effective-hooks-path. Notably classic-hook-shadowed is not, because there GForge itself is running and it is the user's own legacy hook that went dormant.

The report also states why it failed, since a non-zero exit is otherwise inexplicable when every printed line reads PASS or WARN.

Verified end to end against a real gforge verify process in an isolated HOME/GIT_CONFIG_GLOBAL: a shadowed repository exits 0 on master and 1 with this change, while a healthy repository stays 0.

Fixes #42