### PR TITLE
Give each atomic write a unique temp path so concurrent installs cann…

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { chmod, mkdir, readFile, rename, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -373,11 +374,30 @@ async function writeManagedFiles(hooksDirectory, nodePath) {
 
 // Write via a sibling temp file and rename into place so readers (a concurrent
 // git commit, or a crash mid-write) never observe a truncated or empty hook.
+//
+// The temp name must be unique per call. A fixed `${filePath}.gforge-tmp` meant
+// two concurrent installs — two terminals, or several packages triggering
+// postinstall at once in a monorepo — wrote to the SAME temp file and then both
+// renamed it: the result was byte-spliced from both writers, and whichever lost
+// the race got an uncaught ENOENT because the other had already renamed the
+// file away (issue #39). Reproduced at 60/60 iterations before this change.
+//
+// rename(2) is atomic and replaces the destination, so with distinct temp paths
+// concurrent writers are safe: each renames its own complete file and the last
+// one wins, rather than the two being interleaved.
 async function writeFileAtomic(filePath, content, mode) {
-  const tempPath = `${filePath}.gforge-tmp`;
-  await writeFile(tempPath, content, { mode });
-  await chmod(tempPath, mode);
-  await rename(tempPath, filePath);
+  // Keeps the .gforge-tmp suffix so leftover debris is still identifiable.
+  const tempPath = `${filePath}.${process.pid}-${randomUUID()}.gforge-tmp`;
+  try {
+    await writeFile(tempPath, content, { mode });
+    await chmod(tempPath, mode);
+    await rename(tempPath, filePath);
+  } catch (error) {
+    // Never leave a partial temp file behind on failure - it would otherwise
+    // accumulate silently in the user's ~/.gforge/hooks directory forever.
+    await unlink(tempPath).catch(() => {});
+    throw error;
+  }
 }
 
 async function removeManagedFiles(hooksDirectory, statePath) {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -9,6 +9,7 @@ import {
   SCANNER_FILE_NAME,
   getScannerContent,
   resolveHooksDirectory,
+  resolveManagedDirectory,
   resolvePreCommitPath,
   resolveScannerPath,
   resolveStatePath
@@ -354,9 +355,55 @@ test("install leaves no temporary files behind", async () => {
     execFile: git.execFile
   });
 
-  await assert.rejects(stat(`${resolvePreCommitPath(homePath)}.gforge-tmp`), { code: "ENOENT" });
-  await assert.rejects(stat(`${resolveScannerPath(homePath)}.gforge-tmp`), { code: "ENOENT" });
-  await assert.rejects(stat(`${resolveStatePath(homePath)}.gforge-tmp`), { code: "ENOENT" });
+  // Scans for ANY leftover temp file rather than three hardcoded names. Temp
+  // names carry a pid and a uuid since issue #39, so asserting the absence of
+  // one fixed literal path would pass vacuously - that exact name is never
+  // created any more, whether or not debris was actually left behind.
+  const hooksDirectory = resolveHooksDirectory(homePath);
+  for (const directory of [hooksDirectory, resolveManagedDirectory(homePath)]) {
+    const leftover = (await readdir(directory)).filter((name) => name.includes("gforge-tmp"));
+    assert.deepEqual(leftover, [], `unexpected temp files in ${directory}`);
+  }
+});
+
+test("issue #39: concurrent installs cannot splice the managed files together", async () => {
+  // Two installs racing against the same home directory - two terminals, or
+  // several packages triggering postinstall at once in a monorepo. With a
+  // fixed temp path both wrote to the SAME temp file and then both renamed it,
+  // so the installed engine could end up byte-spliced from the two writers,
+  // and the loser of the rename race threw an uncaught ENOENT.
+  const homePath = await createTempHome();
+  const git = createGitConfigMock();
+  const environment = createEnvironment(homePath);
+
+  const results = await Promise.allSettled([
+    installManagedHooks({ environment, execFile: git.execFile }),
+    installManagedHooks({ environment, execFile: git.execFile })
+  ]);
+
+  // Neither install may crash - in particular not with ENOENT from rename().
+  for (const result of results) {
+    assert.equal(result.status, "fulfilled", `install rejected: ${result.reason?.code ?? result.reason}`);
+    assert.equal(result.value.ok, true);
+  }
+
+  // The decisive assertion: the engine on disk is byte-identical to the
+  // packaged source. A spliced file has the right length but wrong content,
+  // so a size check alone would not catch this.
+  assert.equal(await readFile(resolveScannerPath(homePath), "utf8"), getScannerContent());
+
+  // The hook shim must be intact and still executable.
+  const preCommit = await readFile(resolvePreCommitPath(homePath), "utf8");
+  assert.match(preCommit, new RegExp(SCANNER_FILE_NAME));
+  assert.equal(Boolean((await stat(resolvePreCommitPath(homePath))).mode & 0o111), true);
+
+  // The state file must be complete, parseable JSON - not a spliced fragment.
+  const state = JSON.parse(await readFile(resolveStatePath(homePath), "utf8"));
+  assert.equal(state.managedBy, "gforge");
+
+  // And no temp debris survives the race.
+  const leftover = (await readdir(resolveHooksDirectory(homePath))).filter((n) => n.includes("gforge-tmp"));
+  assert.deepEqual(leftover, []);
 });
 
 test("verify warns when a repo-local hooks path shadows the managed hooks", async () => {


### PR DESCRIPTION
…ot corrupt

writeFileAtomic() always wrote to a fixed `${filePath}.gforge-tmp` before renaming into place. Two concurrent installs — two terminals, or several packages triggering postinstall at once in a monorepo — therefore wrote to the SAME temp file and then both renamed it. Two failure modes followed: the installed file could be byte-spliced from both writers, and whichever process lost the rename race threw an uncaught ENOENT because the other had already renamed the temp file away.

Both were reproduced against the real code before fixing. Racing two writes in-process: 60/60 iterations produced an ENOENT and a spliced file (content starting with one payload and ending with the other). Racing two separate processes released from a shared barrier: 25/25 produced the ENOENT and 4/25 produced spliced content — the crash is the reliable symptom across processes, the splice needs a tighter overlap. Worth noting the issue's suggested repro of simply running two `gforge install` commands did not reproduce it for me, because node's startup time dwarfs the race window; the barrier was needed to make the overlap real.

Temp paths now carry the pid and a uuid. rename(2) is atomic and replaces the destination, so with distinct temp paths each writer renames its own complete file and the last one wins, instead of the two interleaving. A failed write also unlinks its temp file rather than leaving debris to accumulate in ~/.gforge/hooks.

Also strengthened the existing "leaves no temporary files behind" test. It asserted the absence of three hardcoded `.gforge-tmp` paths, which would have passed vacuously once names became unique, since those exact names are never created any more. It now scans the directories for any leftover temp file.

Fixes #39