### PR TITLE
Document --ignore-scripts, and say plainly when GForge is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,31 @@ secrets. Confirm anytime with:
 gforge verify
 ```
 
+### If you install with `--ignore-scripts`
+
+`npm install --ignore-scripts` is a reasonable supply-chain precaution, and many
+CI pipelines and lockfile-strict setups enable it globally. It also skips
+GForge's `postinstall` step — which is the step that installs the git hooks.
+
+npm gives no indication that it skipped anything, so the result is the failure
+mode GForge exists to prevent: the `gforge` command is on your PATH and looks
+installed, but **no hook is registered and no commit is ever scanned**.
+
+If you use that flag, run the install step yourself afterwards:
+
+```bash
+npm install -g gforge --ignore-scripts
+gforge install     # registers the hooks that postinstall would have
+```
+
+`gforge verify` reports this state explicitly — it exits non-zero and names
+`not-installed` — so it is worth running once after any install, and worth
+wiring into CI if your pipeline relies on GForge:
+
+```bash
+gforge verify      # exit 0 only when scanning is actually active
+```
+
 ## Quick start
 
 ```bash

--- a/src/installer.js
+++ b/src/installer.js
@@ -266,7 +266,28 @@ export async function verifyManagedHooks(options = {}) {
     if (classicHook) checks.push(classicHook);
   }
 
-  checks.push(await checkDirectory(hooksDirectory));
+  const directoryCheck = await checkDirectory(hooksDirectory);
+
+  // Nothing is installed at all. Running the per-file checks here produces four
+  // cascading FAILs for a single root cause, and one of them ("engine not found
+  // - run `gforge update`") gives actively wrong advice: update refreshes an
+  // existing install, it is not how you set one up. Say it once, correctly, and
+  // name the cause that produces this state silently - `npm install
+  // --ignore-scripts` skips the postinstall step that installs the hooks, so
+  // the package is on PATH while nothing is ever scanned (issue #53).
+  if (directoryCheck.missing) {
+    checks.push({
+      status: "FAIL",
+      label: "not-installed",
+      detail:
+        `no managed hooks at ${hooksDirectory} - GForge is not installed, so no commit is being scanned. ` +
+        "If it was installed with `npm install --ignore-scripts`, the postinstall step that installs the " +
+        "hooks never ran. Run `gforge install` to set them up."
+    });
+    return { hooksDirectory, checks };
+  }
+
+  checks.push(directoryCheck);
 
   const scannerPath = resolveScannerPath(environment.home.path);
   checks.push(await checkScannerContent(scannerPath));
@@ -549,6 +570,9 @@ async function checkDirectory(hooksDirectory) {
     };
   } catch {
     return {
+      // Distinguishes "nothing is installed" from "something is wrong with what
+      // is installed" - the two need different remedies (see issue #53).
+      missing: true,
       status: "FAIL",
       label: "hooks-directory",
       detail: `${hooksDirectory} not found`

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -287,6 +287,56 @@ test("verify reports missing managed hooks", async () => {
   assert.equal(report.checks.some((check) => check.status === "FAIL"), true);
 });
 
+test("issue #53: an uninstalled GForge says so once, with the right remedy", async () => {
+  // The state `npm install --ignore-scripts` leaves behind: the package is on
+  // PATH but postinstall never ran, so no hook exists and nothing is scanned.
+  const homePath = await createTempHome();
+  const report = await verifyManagedHooks({
+    environment: createEnvironment(homePath),
+    execFile: createGitConfigMock().execFile
+  });
+
+  const notInstalled = report.checks.find((check) => check.label === "not-installed");
+  assert.ok(notInstalled, "expected a not-installed check");
+  assert.equal(notInstalled.status, "FAIL");
+  // Names the silent cause, and gives the remedy that actually applies.
+  assert.match(notInstalled.detail, /--ignore-scripts/);
+  assert.match(notInstalled.detail, /gforge install/);
+
+  // `gforge update` refreshes an existing install; it is the wrong advice for
+  // something that was never installed, and used to be what verify printed.
+  assert.equal(/gforge update/.test(report.checks.map((c) => c.detail).join("\n")), false);
+
+  // One root cause, not four cascading per-file failures for the same thing.
+  for (const label of [`${SCANNER_FILE_NAME}-content`, "pre-commit-content", "pre-commit-executable"]) {
+    assert.equal(report.checks.some((check) => check.label === label), false, `${label} should be suppressed`);
+  }
+});
+
+test("issue #53: an installed-but-broken GForge still gets the per-file checks", async () => {
+  // The suppression above must be scoped to "nothing installed at all" - once
+  // the hooks exist, a stale or tampered engine still has to be reported, and
+  // there `gforge update` IS the right remedy.
+  const homePath = await createTempHome();
+  const git = createGitConfigMock();
+
+  await installManagedHooks({
+    environment: createEnvironment(homePath),
+    execFile: git.execFile
+  });
+  await writeFile(resolveScannerPath(homePath), "// tampered\n");
+
+  const report = await verifyManagedHooks({
+    environment: createEnvironment(homePath),
+    execFile: git.execFile
+  });
+
+  assert.equal(report.checks.some((check) => check.label === "not-installed"), false);
+  const scannerCheck = report.checks.find((check) => check.label === `${SCANNER_FILE_NAME}-content`);
+  assert.equal(scannerCheck.status, "FAIL");
+  assert.match(scannerCheck.detail, /gforge update/);
+});
+
 test("installs both managed files and delegates the pre-commit shim to the scanner", async () => {
   const homePath = await createTempHome();
   const git = createGitConfigMock();


### PR DESCRIPTION
`npm install --ignore-scripts` is a reasonable supply-chain precaution and is enabled wholesale by many CI pipelines, but it skips the postinstall step that registers the git hooks. npm reports nothing, so the result is the exact failure this tool exists to prevent: `gforge` is on PATH and looks installed, while no hook is registered and no commit is scanned.

npm will not run postinstall under that flag, so this cannot be fixed by making postinstall smarter. What it can do is stop being silent:

- README now documents the interaction, with the `gforge install` follow-up and a note that `gforge verify` exits non-zero in this state so it can be wired into CI.

- verify now reports the never-installed state as a single `not-installed` FAIL that names --ignore-scripts as the likely cause. Previously it emitted four cascading FAILs for one root cause, and one of them told the user to run `gforge update` — which refreshes an existing install and is not how you set one up. The suppression is scoped strictly to "no managed hooks directory at all"; once the hooks exist, a stale or tampered engine still reports per-file, where `gforge update` is correct.

Verified end to end against a real gforge verify in an isolated HOME/GIT_CONFIG_GLOBAL: the uninstalled state now prints one actionable line instead of five, a healthy install is unchanged and all-PASS, and a tampered engine still fails the per-file content check.

Fixes #53