### PR TITLE
Remove the dead route-segment length floor left by the #45/#68 merge

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -269,7 +269,6 @@ function looksLikeRouteSegment(segment) {
   if (digits > PATH_SEGMENT_MAX_DIGITS && digits / word.length > PATH_SEGMENT_MAX_DIGIT_RATIO) return false;
   if (maxConsonantRun(word) > ROUTE_MAX_CONSONANT_RUN) return false;
   if (word.length < ROUTE_SEGMENT_MIN_CHECK_LENGTH) return true; // api, v1, graphqlws
-  if (word.length < NAME_SEGMENT_MIN_CHECK_LENGTH) return true; // api, v1, uuid
   const letters = word.replace(/[^a-z]/g, "");
   return letters.length > 0 && ratioOf(letters, /[aeiou]/g) >= ROUTE_MIN_VOWEL_RATIO;
 }


### PR DESCRIPTION
looksLikeRouteSegment carried two stacked length floors:

    if (word.length < ROUTE_SEGMENT_MIN_CHECK_LENGTH) return true;  // 12
    if (word.length < NAME_SEGMENT_MIN_CHECK_LENGTH) return true;   // 8

The second is unreachable. It is only evaluated when the length is at least 12, at which point "shorter than 8" can never hold. PR #69 meant to replace that line - its diff removes the NAME line and adds the ROUTE one - but resolving the conflict against #67 kept both.

Confirmed dead before removing it: replacing the line with a throw and running the suite plus 10,005 generated route segments covering every length from 1 to 25 produced zero hits.

Confirmed behaviour-preserving after removing it: a deterministic corpus of 23,430 route-shaped lines produces a byte-identical rule-id fingerprint before and after (sha256 fae46d41...), 17,435 of them flagged either way.

The NAME_SEGMENT_MIN_CHECK_LENGTH constant stays - the entropy layer still uses it for path segments.

No behaviour change; this is a readability fix. The stacked pair read as though the route layer had two floors when only the 12 was live, and this function has already been the subject of three issues (#23, #45, #68).

Fixes #72