### PR TITLE
Detect the Node.js version and fail verify below the declared minimum

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -7,6 +7,29 @@ const execFileAsync = promisify(execFile);
 const SUPPORTED_PLATFORMS = new Set(["darwin", "linux", "win32"]);
 const SUPPORTED_SHELLS = new Set(["bash", "zsh", "pwsh", "powershell"]);
 
+// Mirrors `engines.node` in package.json. Kept as a literal rather than parsed
+// from package.json at runtime so detection stays dependency- and I/O-free;
+// a test asserts the two never drift apart (issue #52).
+export const MIN_NODE_MAJOR = 20;
+
+// npm only enforces `engines` when engine-strict is on, so gforge can be
+// installed and run on an older Node than it supports. Nothing then reports
+// that, and the first symptom is an unrelated-looking runtime error somewhere
+// else in the tool - so detect it and let verify say so plainly (issue #52).
+export function detectNode(rawVersion = process.versions.node) {
+  const version = String(rawVersion ?? "").trim() || null;
+  const match = version?.match(/^v?(\d+)\./);
+  const major = match ? Number(match[1]) : null;
+
+  return {
+    version,
+    major,
+    // Unparseable fails closed (treated as unsupported) rather than assuming
+    // support, matching how the git-version gate handles the same ambiguity.
+    supported: major !== null && major >= MIN_NODE_MAJOR
+  };
+}
+
 export async function detectEnvironment(options = {}) {
   const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
@@ -32,6 +55,7 @@ export async function detectEnvironment(options = {}) {
       name: shellName,
       supported: shellName ? SUPPORTED_SHELLS.has(shellName) : false
     },
+    node: detectNode(options.nodeVersion ?? process.versions.node),
     git: await detectGit(execFileFn)
   };
 }

--- a/src/verify.js
+++ b/src/verify.js
@@ -1,3 +1,5 @@
+import { MIN_NODE_MAJOR } from "./environment.js";
+
 export function createVerificationReport(environment, managedHooksReport = null, dotenvReport = null) {
   const checks = [
     {
@@ -19,7 +21,8 @@ export function createVerificationReport(environment, managedHooksReport = null,
       status: environment.git.available ? "PASS" : "FAIL",
       label: "git",
       detail: environment.git.available ? environment.git.rawVersion : "git not found"
-    }
+    },
+    nodeCheck(environment.node)
   ];
 
   const allChecks = [
@@ -97,6 +100,32 @@ export function formatVerificationReport(report) {
   }
 
   return `${lines.join("\n")}\n`;
+}
+
+// The package declares engines.node, but npm only enforces that under
+// engine-strict - so gforge can be running right now on a Node it does not
+// support, with nothing saying so. Not marked `blocking`: unlike a shadowed
+// hooksPath, an old runtime does not prove scanning is inactive, it proves it
+// is untested. FAIL is still right, since the exit code should not call an
+// unsupported runtime healthy (issue #52).
+function nodeCheck(node) {
+  if (!node) {
+    return { status: "FAIL", label: "node", detail: "Node.js version not detected" };
+  }
+  if (node.supported) {
+    return { status: "PASS", label: "node", detail: `Node.js ${node.version}` };
+  }
+  // An unparseable version is not "below" the minimum, it is unreadable - say
+  // which one it actually is rather than implying a comparison that never ran.
+  const problem =
+    node.major === null
+      ? `could not read the Node.js version${node.version ? ` (got "${node.version}")` : ""}`
+      : `Node.js ${node.version} is below the required Node.js ${MIN_NODE_MAJOR}`;
+  return {
+    status: "FAIL",
+    label: "node",
+    detail: `${problem} - GForge is untested here and may fail in ways that look unrelated. Upgrade Node.`
+  };
 }
 
 function formatShell(shell) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -78,6 +78,7 @@ test("runs read-only verification", async () => {
       platform: { name: "darwin", arch: "arm64", supported: true, isWsl: false },
       home: { path: "/Users/example", present: true },
       shell: { path: "/bin/zsh", name: "zsh", supported: true },
+      node: { version: "20.11.0", major: 20, supported: true },
       git: { available: true, version: "2.45.0", rawVersion: "git version 2.45.0" }
     }),
     verifyManagedHooks: async () => ({
@@ -107,6 +108,7 @@ test("fails verification when git is unavailable", async () => {
       platform: { name: "darwin", arch: "arm64", supported: true, isWsl: false },
       home: { path: "/Users/example", present: true },
       shell: { path: "/bin/zsh", name: "zsh", supported: true },
+      node: { version: "20.11.0", major: 20, supported: true },
       git: { available: false, version: null, rawVersion: null, errorCode: "ENOENT" }
     }),
     verifyManagedHooks: async () => ({

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-import { detectEnvironment } from "../src/environment.js";
+import { MIN_NODE_MAJOR, detectEnvironment, detectNode } from "../src/environment.js";
 
 test("detects supported Unix environment and Git", async () => {
   const environment = await detectEnvironment({
@@ -75,4 +76,60 @@ test("reports missing Git without throwing", async () => {
 
   assert.equal(environment.git.available, false);
   assert.equal(environment.git.errorCode, "ENOENT");
+});
+
+test("issue #52: detects the running Node.js version and whether it is supported", async () => {
+  const environment = await detectEnvironment({
+    env: { SHELL: "/bin/zsh" },
+    platform: "linux",
+    arch: "x64",
+    homeDirectory: "/home/example",
+    nodeVersion: "22.14.0",
+    execFile: async () => ({ stdout: "git version 2.45.0\n" })
+  });
+
+  assert.deepEqual(environment.node, { version: "22.14.0", major: 22, supported: true });
+});
+
+test("issue #52: a Node below the declared minimum is reported unsupported", () => {
+  assert.equal(detectNode("18.20.4").supported, false);
+  assert.equal(detectNode("18.20.4").major, 18);
+  // Boundary: the declared minimum itself is supported.
+  assert.equal(detectNode(`${MIN_NODE_MAJOR}.0.0`).supported, true);
+  assert.equal(detectNode(`${MIN_NODE_MAJOR - 1}.99.99`).supported, false);
+  // A leading "v" is tolerated (process.versions.node omits it, but
+  // `node --version` and most other sources include it).
+  assert.equal(detectNode("v22.0.0").supported, true);
+});
+
+test("issue #52: an undetectable Node version fails closed, not open", () => {
+  // Matches how the git-version gate treats an unparseable version: assume
+  // unsupported rather than quietly assuming it is fine. Note a bare major
+  // ("20") is deliberately in here - the pattern requires a dotted version, so
+  // anything that shape is treated as unrecognised rather than guessed at.
+  for (const bogus of ["", "   ", null, "not-a-version", "20"]) {
+    assert.equal(detectNode(bogus).supported, false, `expected ${JSON.stringify(bogus)} unsupported`);
+    assert.equal(detectNode(bogus).major, null);
+  }
+});
+
+test("issue #52: calling detectNode with no argument reads the running Node", () => {
+  // `undefined` is NOT a fail-closed case - it means "use the default", which
+  // is the whole point of the parameter. The process running this test meets
+  // the minimum, so this must report supported.
+  assert.deepEqual(detectNode(), detectNode(process.versions.node));
+  assert.equal(detectNode().version, process.versions.node);
+  assert.equal(detectNode().supported, true);
+});
+
+test("issue #52: MIN_NODE_MAJOR stays in sync with package.json engines.node", async () => {
+  // The constant is a literal so detection needs no file I/O; this guards the
+  // drift that choice invites.
+  const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+  const declared = Number(String(pkg.engines.node).match(/(\d+)/)?.[1]);
+  assert.equal(
+    MIN_NODE_MAJOR,
+    declared,
+    `MIN_NODE_MAJOR (${MIN_NODE_MAJOR}) must match package.json engines.node (${pkg.engines.node})`
+  );
 });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -9,6 +9,7 @@ test("creates successful report when required checks pass", () => {
       platform: { name: "linux", arch: "x64", supported: true },
       home: { path: "/home/example", present: true },
       shell: { path: "/bin/bash", name: "bash", supported: true },
+      node: { version: "20.11.0", major: 20, supported: true },
       git: { available: true, rawVersion: "git version 2.45.0" }
     },
     {
@@ -67,6 +68,7 @@ test("formats warnings without failing verification", () => {
     platform: { name: "linux", arch: "x64", supported: true },
     home: { path: "/home/example", present: true },
     shell: { path: null, name: null, supported: false },
+    node: { version: "20.11.0", major: 20, supported: true },
     git: { available: true, rawVersion: "git version 2.45.0" }
   });
 
@@ -139,6 +141,7 @@ test("issue #42: a FAIL still fails, and combines with blocking checks", () => {
     platform: { name: "linux", arch: "x64", supported: true },
     home: { path: "/home/example", present: true },
     shell: { path: "/bin/bash", name: "bash", supported: true },
+    node: { version: "20.11.0", major: 20, supported: true },
     git: { available: false, rawVersion: null }
   });
 
@@ -146,11 +149,47 @@ test("issue #42: a FAIL still fails, and combines with blocking checks", () => {
   assert.deepEqual(report.blocking, []);
 });
 
+test("issue #52: verify reports the Node version, and fails on one below the minimum", () => {
+  const healthy = createVerificationReport(healthyEnvironment());
+  const nodePass = healthy.checks.find((check) => check.label === "node");
+  assert.ok(nodePass, "expected a node check");
+  assert.equal(nodePass.status, "PASS");
+  assert.match(formatVerificationReport(healthy), /PASS node: Node\.js 20\.11\.0/);
+
+  const old = createVerificationReport({
+    ...healthyEnvironment(),
+    node: { version: "18.20.4", major: 18, supported: false }
+  });
+  const nodeFail = old.checks.find((check) => check.label === "node");
+  assert.equal(nodeFail.status, "FAIL");
+  assert.match(nodeFail.detail, /18\.20\.4/);
+  assert.match(nodeFail.detail, /Upgrade Node/);
+  assert.equal(old.exitCode, 1);
+
+  // A FAIL, not a blocking check: an old runtime is untested, but it does not
+  // prove that scanning is inactive the way a shadowed hooksPath does - so the
+  // "Not protected" banner must not appear.
+  assert.deepEqual(old.blocking, []);
+  assert.equal(/Not protected/.test(formatVerificationReport(old)), false);
+});
+
+test("issue #52: a missing node field is reported rather than silently passing", () => {
+  // Defensive: an environment object assembled without node detection must not
+  // quietly count as healthy.
+  const { node, ...withoutNode } = healthyEnvironment();
+  const report = createVerificationReport(withoutNode);
+
+  const check = report.checks.find((c) => c.label === "node");
+  assert.equal(check.status, "FAIL");
+  assert.equal(report.exitCode, 1);
+});
+
 function healthyEnvironment() {
   return {
     platform: { name: "linux", arch: "x64", supported: true },
     home: { path: "/home/example", present: true },
     shell: { path: "/bin/bash", name: "bash", supported: true },
+    node: { version: "20.11.0", major: 20, supported: true },
     git: { available: true, rawVersion: "git version 2.45.0" }
   };
 }


### PR DESCRIPTION
package.json declares engines.node >= 20, but npm only enforces engines under engine-strict, so gforge can be installed and run on an older Node than it supports. Nothing detected or reported that: environment detection covered platform, shell, WSL and git, but never Node, so verify had no way to flag its own stated minimum being unmet. The first symptom was an unrelated-looking runtime error somewhere else in the tool.

detectEnvironment now reports `node: { version, major, supported }`, and verify carries a `node` check alongside platform/home/shell/git.

Two judgement calls worth stating:

- FAIL rather than WARN. The exit code should not call an unsupported runtime healthy. It is deliberately NOT marked `blocking` (the flag added for issue #42): a shadowed hooksPath proves scanning is inactive, whereas an old runtime proves only that it is untested, so the "Not protected" banner stays reserved for the former.

- MIN_NODE_MAJOR is a literal rather than parsed from package.json at runtime, keeping detection I/O- and dependency-free. A test asserts the two never drift, and was confirmed to fail when engines.node is changed on its own.

An unparseable version reports "could not read the Node.js version" rather than claiming it is "below" the minimum, since no comparison actually ran. Unparseable still fails closed, matching how the existing git-version gate treats the same ambiguity.

Verified through the real detectEnvironment -> createVerificationReport chain: 18.20.4 exits 1, 20.0.0 and 24.12.0 exit 0, and unreadable values exit 1 with the unreadable wording. Only Node 24 is installed here, so the sub-20 path was exercised by injecting the version rather than by running an actually old runtime.

Fixes #52