### PR TITLE
Add named provider rules for Azure Storage, Entra ID and Vonage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ so the standard is enforced by default, not by discipline.
   - **`.env` cross-reference** — blocks any staged file that hardcodes a real value
     from your git-ignored `.env` files (the classic "pasted a token out of `.env`"),
     including per-package `.env` files in a monorepo, not just the repo root.
-  - **Provider rules** — 25+ credential shapes: AWS, GitHub/GitLab, Google, Slack,
-    Stripe, Twilio, SendGrid, npm, PyPI, OpenAI/Anthropic, PEM private keys, JWTs,
+  - **Provider rules** — 25+ credential shapes: AWS, Azure (Storage keys and
+    Entra ID client secrets), GitHub/GitLab, Google, Slack, Stripe, Twilio,
+    Vonage, SendGrid, npm, PyPI, OpenAI/Anthropic, PEM private keys, JWTs,
     database URLs, and more.
   - **Generic secrets** — any credential keyword assigned to a hardcoded value
     (`DB_PASSWORD=…`, `password: "…"`, `api_key = "…"`).

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -83,7 +83,37 @@ export const PROVIDER_RULES = [
   { id: "stripe-secret-key", description: "Stripe secret/restricted key", regex: /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}\b/ },
   { id: "google-api-key", description: "Google API key", regex: /\bAIza[0-9A-Za-z_-]{35}\b/ },
   { id: "gcp-oauth-secret", description: "Google OAuth client secret", regex: /\bGOCSPX-[A-Za-z0-9_-]{20,}\b/ },
+  // An Azure Storage account key is a 512-bit key, so its base64 form is always
+  // 86 characters plus "==" padding. Anchoring on the literal AccountKey= makes
+  // this effectively false-positive free (issue #28).
+  {
+    id: "azure-storage-key",
+    description: "Azure Storage account key",
+    regex: /\bAccountKey=[A-Za-z0-9+/]{86}==/
+  },
+  // An Entra ID (Azure AD) client secret is 40 characters from a restricted
+  // alphabet and carries a "~" a few characters in. The length is matched
+  // exactly, via a lookahead, because that discipline is what keeps this off
+  // ordinary 40-character strings - a 40-hex SHA and a "~/..." home path both
+  // stay clear (issue #28).
+  {
+    id: "azure-entra-client-secret",
+    description: "Azure Entra ID (Azure AD) client secret",
+    regex: /(?<![A-Za-z0-9._~-])(?=[A-Za-z0-9._~-]{40}(?![A-Za-z0-9._~-]))[A-Za-z0-9._-]{2,8}~[A-Za-z0-9._~-]+/
+  },
   { id: "twilio-api-key", description: "Twilio API key/SID", regex: /\b(?:SK|AC)[0-9a-fA-F]{32}\b/ },
+  // A Vonage/Nexmo API secret is 16 alphanumerics with no prefix - far too
+  // generic to match on shape alone (a bare 16-character run occurs 130 times
+  // in this repository's own source). So both alternatives anchor on something
+  // Vonage-specific instead: the literal api_secret parameter, or the SDK's
+  // positional (8-char key, 16-char secret) constructor. The lookbehind rather
+  // than \b is deliberate, so the VONAGE_API_SECRET= env form still matches -
+  // \b does not fire between an underscore and a letter (issue #28).
+  {
+    id: "vonage-api-secret",
+    description: "Vonage/Nexmo API secret",
+    regex: /(?<![A-Za-z0-9])api_secret=[A-Za-z0-9]{16}(?![A-Za-z0-9])|new\s+Vonage\s*\(\s*["'][A-Za-z0-9]{8}["']\s*,\s*["'][A-Za-z0-9]{16}["']/i
+  },
   { id: "sendgrid-key", description: "SendGrid API key", regex: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}\b/ },
   { id: "mailgun-key", description: "Mailgun API key", regex: /\bkey-[0-9a-zA-Z]{32}\b/ },
   { id: "mailchimp-key", description: "Mailchimp API key", regex: /\b[0-9a-f]{32}-us[0-9]{1,2}\b/ },

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -110,6 +110,68 @@ test("detects provider tokens and private keys", () => {
   assert.ok(ruleIds("a", "-----BEGIN RSA PRIVATE KEY-----").includes("private-key"));
 });
 
+// A real Azure Storage account key is a 512-bit key, so base64 is always 86
+// characters plus "==" padding. This one decodes to readable filler text.
+const AZURE_ACCOUNT_KEY = "Z2ZvcmdlLWZha2UtYXp1cmUtc3RvcmFnZS1rZXktZm9yLXRlc3RzLWRvLW5vdC11c2UtMDAwMDAwMDAwMDAwMA==";
+const ENTRA_SECRET = "8Xy7Q~aBcDeFgHiJkLmNoPqRsTuVwXyZ012345aB"; // 40 chars, tilde early
+
+test("issue #28: detects Azure Storage, Entra ID and Vonage credentials by name", () => {
+  const connectionString = `DefaultEndpointsProtocol=https;AccountName=store;AccountKey=${AZURE_ACCOUNT_KEY};EndpointSuffix=core.windows.net`;
+  assert.ok(ruleIds("a.js", `const cs = "${connectionString}";`).includes("azure-storage-key"));
+  assert.ok(ruleIds(".env", `AZURE_STORAGE_CONNECTION_STRING=${connectionString}`).includes("azure-storage-key"));
+
+  assert.ok(ruleIds("a.js", `const s = "${ENTRA_SECRET}";`).includes("azure-entra-client-secret"));
+  // The point of a named rule: it does not depend on the variable being called
+  // something incriminating, which is how the generic layer is evaded.
+  assert.ok(ruleIds("a.js", `const cfg = { v: "${ENTRA_SECRET}" };`).includes("azure-entra-client-secret"));
+
+  // Vonage's own query-parameter form, and the SCREAMING_SNAKE env form.
+  assert.ok(
+    ruleIds("a.js", 'fetch("https://rest.nexmo.com/sms/json?api_key=a1b2c3d4&api_secret=aBcDeF1234567890");')
+      .includes("vonage-api-secret")
+  );
+  assert.ok(ruleIds(".env", "VONAGE_API_SECRET=aBcDeF1234567890").includes("vonage-api-secret"));
+  // The SDK's positional (key, secret) constructor carries no credential
+  // keyword at all, so nothing else in the pipeline catches it.
+  assert.ok(
+    ruleIds("a.js", 'const v = new Vonage("a1b2c3d4", "abcdefghijklmnop");').includes("vonage-api-secret")
+  );
+});
+
+test("issue #28: the new provider rules run where the heuristic layers are skipped", () => {
+  // This is what a named rule buys over generic/entropy. Documentation and
+  // generated output skip the two heuristic layers by design (issue #24), so
+  // before these rules an Azure key pasted into a README was missed entirely.
+  assert.ok(ruleIds("README.md", `AccountKey=${AZURE_ACCOUNT_KEY}`).includes("azure-storage-key"));
+  assert.ok(ruleIds("docs/setup.md", `client secret ${ENTRA_SECRET}`).includes("azure-entra-client-secret"));
+  assert.ok(
+    ruleIds("dist/bundle.js", 'new Vonage("a1b2c3d4", "abcdefghijklmnop")').includes("vonage-api-secret")
+  );
+});
+
+test("issue #28: the new rules stay off look-alike values", () => {
+  // Entra secrets are exactly 40 characters; that discipline is what keeps the
+  // rule off ordinary strings that happen to contain a tilde.
+  for (const length of [38, 39, 41, 50]) {
+    const nearMiss = `8Xy7Q~${"a".repeat(length - 6)}`;
+    assert.equal(ruleIds("a.js", `const s = "${nearMiss}";`).includes("azure-entra-client-secret"), false, `len ${length}`);
+  }
+  assert.equal(ruleIds("a.js", 'const p = "~/Library/Application Support/Code/User/x";').includes("azure-entra-client-secret"), false);
+  assert.equal(
+    ruleIds("a.js", 'const sha = "0123456789abcdef0123456789abcdef01234567";').includes("azure-entra-client-secret"),
+    false
+  );
+
+  // A bare 16-character run is far too common to flag on shape alone - it
+  // occurs over a hundred times in this repository's own source - so the
+  // Vonage rule anchors on something Vonage-specific instead.
+  assert.equal(ruleIds("a.js", "const id = 'a1b2c3d4e5f6g7h8';").includes("vonage-api-secret"), false);
+  // A reference is not a hardcoded secret.
+  assert.equal(ruleIds("a.js", "const u = `?api_secret=${process.env.VONAGE_SECRET}`;").includes("vonage-api-secret"), false);
+  // Truncated/short values are not account keys.
+  assert.equal(ruleIds("a.js", 'const k = "AccountKey=tooshort==";').includes("azure-storage-key"), false);
+});
+
 test("detects credentials embedded in a URL", () => {
   assert.ok(ruleIds("a", "postgres://user:supersecret@db:5432/app").includes("basic-auth-url"));
 });


### PR DESCRIPTION
PROVIDER_RULES had no entry for Azure or Vonage, so those credentials reached only the generic-keyword and entropy layers. Measured against the current scanner, that leaves real gaps:

- An Azure Storage AccountKey or an Entra client secret pasted into a README or into dist/ was missed entirely. Documentation and generated paths deliberately skip both heuristic layers (issue #24), and provider rules are precisely the layer that is supposed to still run there.
- An Entra secret assigned to a bland name was caught by entropy alone, which is exactly the fragility the issue describes.
- The Vonage SDK's positional constructor, new Vonage(key, secret), carries no credential keyword at all and scored too low for entropy, so nothing in the pipeline caught it.
- An Azure SAS token was caught by entropy in only 1 of 3 sampled keys - the same shape detected or missed depending on the random bytes.

Each pattern is anchored on something provider-specific rather than on a generic shape:

- azure-storage-key keys off the literal AccountKey=, plus the fixed 86-char + "==" base64 of a 512-bit key.
- azure-entra-client-secret matches the 40-character length exactly via a lookahead. That discipline is what keeps it off a 40-hex SHA or a "~/..." path, which a looser "40 chars containing ~" would catch.
- vonage-api-secret does NOT match a bare 16-character run: that shape occurs 130 times in this repository's own source. It anchors on the api_secret parameter or the positional SDK constructor instead. The lookbehind rather than \b is deliberate so VONAGE_API_SECRET= still matches, since \b does not fire between an underscore and a letter.

False positives measured, not assumed: scanning all 88 files in this repository through the real pipeline produces zero hits from the three new rules outside the fixtures added here.

Azure SAS tokens are deliberately left out. They are a real gap, but the issue does not name them and a sig= pattern needs more care to anchor safely than this change should carry.

Fixes #28