### PR TITLE
Gate auto-update behind per-tier quarantine windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,59 @@ Maximum coverage occasionally flags something safe. Three escape hatches:
 ## Staying up to date
 
 `gforge update` upgrades the package to the latest published release and refreshes
-the hook — no manual `npm install` needed. GForge also keeps itself current on its
-own: at most once a day it checks for a new version in a detached background
-process (it never delays or blocks a commit), installs it, and prints a one-line
-notice on commit:
+the hook — no manual `npm install` needed.
+
+GForge also keeps itself current on its own. At most once a day it checks the
+registry in a detached background process (it never delays or blocks a commit)
+and installs what is eligible. Auto-update is **on by default**, because a stale
+scanner is its own security problem — detection rules improve continuously, and a
+workstation pinned several versions back is quietly less protected.
+
+To bound the risk that comes with an unattended update channel, each release tier
+has to sit on the registry for a **quarantine window** before it will install:
+
+| Tier | Quarantine | Auto-installs | Can be disabled |
+| --- | --- | --- | --- |
+| patch | 48 hours | yes | **no** |
+| minor | 7 days | yes | yes |
+| major | 30 days, and only when tagged `lts` | yes | yes |
+
+The window exists because a compromised publishing credential would ship a
+*patch* — that is the fastest-moving tier — so the delay is what gives a bad
+release time to be noticed and pulled. Patch updates are deliberately not
+disableable: that is where security and critical fixes to GForge itself ship.
+
+Majors never install silently. A new major always prints a notice, and only
+auto-installs if it is tagged `lts` and has been published 30 days:
 
 ```
-gforge: v1.2.0 is available (you have v1.1.0). Run: gforge update
+!! gforge v2.0.0 is a new LTS major (you have v1.5.2). It installs automatically
+   once it has been published 30 days; run `gforge update` to take it now.
+
+gforge v2.1.0 is a new major (you have v1.5.2). It is not marked LTS, so it will
+not install automatically. Run `gforge update` to take it.
 ```
+
+Every unattended install is recorded in `~/.gforge/update-log` and announced on
+the next commit (`gforge: auto-updated v1.5.2 -> v1.5.3`), so an update is never
+something that just silently happened to your machine.
+
+### Turning auto-update off
+
+```bash
+gforge settings                     # show the current state
+gforge settings --no-autoupdate     # stop auto-installing minor and major releases
+gforge settings --autoupdate        # re-enable
+```
+
+This is stored in `~/.gforge/settings.json` and survives updates. Prefer it over
+the `GFORGE_AUTO_UPDATE` environment variable: the hook runs as
+`git → sh → node`, which does not inherit your shell profile when you commit from
+a GUI client, so an env var set in `.zshrc` can silently fail to apply.
+
+Patch updates continue after `--no-autoupdate`. If you need to stop those too,
+uninstall (`gforge uninstall`) — a security tool that can silently skip its own
+security fixes is not a state worth supporting.
 
 ## Configuration
 
@@ -208,7 +253,7 @@ file to manage.
 
 | Variable | Effect |
 | --- | --- |
-| `GFORGE_AUTO_UPDATE=0` | Notify only; do not auto-install new versions (default: auto-install on). |
+| `GFORGE_AUTO_UPDATE=0` | Disable minor/major auto-install (default: on). Overrides `gforge settings`, and treats any value that is not `1`/`true`/`on`/`yes` as off. Patch updates still install — see [Staying up to date](#staying-up-to-date). |
 | `GFORGE_NO_SELF_UPDATE=1` | Skip the npm self-upgrade in `install`/`update` (CI / air-gapped). |
 | `GFORGE_SKIP_POSTINSTALL=1` | Skip automatic hook setup during `npm install`. |
 | `GFORGE_NODE=/path/to/node` | Pin the Node.js runtime the hook uses. |

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,7 @@ import {
   readCachedUpdateNotice
 } from "./npm-update.js";
 import { describeDotenvSources } from "./scanner.js";
+import { runSettingsCommand } from "./settings.js";
 import { createVerificationReport, formatVerificationReport } from "./verify.js";
 
 export async function runCli(args, streams, options = {}) {
@@ -35,6 +36,10 @@ export async function runCli(args, streams, options = {}) {
 
   if (command === "uninstall") {
     return runMutation("uninstall", options.uninstallManagedHooks ?? uninstallManagedHooks, options, streams);
+  }
+
+  if (command === "settings") {
+    return (options.runSettingsCommand ?? runSettingsCommand)(args, streams, options);
   }
 
   if (command === "verify") {
@@ -181,11 +186,12 @@ function helpText(stream) {
     row("verify", "Verify the environment and installed hooks (read-only)"),
     row("update", "Upgrade to the latest version (if any) and refresh the hooks"),
     row("uninstall", "Remove GForge-owned hooks and restore your Git config"),
+    row("settings", "Show settings; --no-autoupdate / --autoupdate (minor+major)"),
     row("version", "Display the version"),
     row("help", "Display this help"),
     "",
     header("Environment:"),
-    row("GFORGE_AUTO_UPDATE=0", "Disable automatic background upgrades (on by default)", 30),
+    row("GFORGE_AUTO_UPDATE=0", "Disable minor/major auto-update (overrides settings)", 30),
     row("GFORGE_NO_SELF_UPDATE=1", "Skip the npm self-upgrade in install / update", 30),
     row("GFORGE_SKIP_POSTINSTALL=1", "Skip auto-setup during npm install", 30),
     row("GFORGE_NO_DEFAULT_EXCLUDES=1", "Scan translations, docs and build output too", 30),

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -1100,18 +1100,61 @@ export function runPreCommit(write = (s) => process.stderr.write(s)) {
 }
 
 // ---------------------------------------------------------------------------
-// Update notification (never blocks or delays the commit).
+// Update notification and tiered auto-update (never blocks or delays a commit).
 //
 // The commit path only READS a cache written by a detached background check, so
-// no network happens on the critical path. Once/day the hook fire-and-forgets a
-// background refresh of that cache; with GFORGE_AUTO_UPDATE=1 the background
-// process also upgrades the package.
+// no network happens on the critical path. Once a day the hook fire-and-forgets
+// a background refresh of that cache, and that background process is also what
+// installs an update.
+//
+// Auto-update is ON by default, because a stale scanner is its own security
+// problem - this project ships detection fixes continuously. The blast radius of
+// a compromised publish is bounded by a quarantine window instead, per tier
+// (issue #29):
+//
+//   patch  48h,     always on - this is where security fixes to GForge ship
+//   minor  7 days,  user-disableable
+//   major  30 days AND tagged `lts`, user-disableable
+//
+// Semver is a claim made by the *publisher*, and in this threat model the
+// publisher is the compromised party - a hostile release would be published as a
+// patch, precisely because that tier moves fastest. So the patch tier gets a
+// real (if short) window rather than zero: long enough for a bad release to be
+// noticed and yanked, short enough that a genuine fix still lands the same week.
 // ---------------------------------------------------------------------------
 const UPDATE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const REGISTRY_URL = "https://registry.npmjs.org/gforge/latest";
+// The full packument, not /gforge/latest: only this response carries the `time`
+// map of publish timestamps that quarantine needs, and the `dist-tags` the LTS
+// rule needs. Measured at ~33KB vs ~1KB, fetched at most once a day off the
+// commit path, so the extra bytes buy both signals for free.
+const REGISTRY_URL = "https://registry.npmjs.org/gforge";
+
+export const QUARANTINE_MS = {
+  patch: 48 * 60 * 60 * 1000,
+  minor: 7 * 24 * 60 * 60 * 1000,
+  major: 30 * 24 * 60 * 60 * 1000
+};
 
 function updateCachePath() {
   return join(homedir(), ".gforge", "update-check.json");
+}
+
+function updateLogPath() {
+  return join(homedir(), ".gforge", "update-log");
+}
+
+export function settingsPath(home = homedir()) {
+  // Deliberately NOT state.json: installManagedHooks rewrites that on every
+  // update, so a preference stored there would be wiped by the very auto-update
+  // it governs (issue #29).
+  return join(home, ".gforge", "settings.json");
+}
+
+// Plain release versions only. A prerelease or build-tagged version is never an
+// auto-update target - those are opt-in by definition.
+export function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(String(value ?? "").trim());
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
 }
 
 function versionIsNewer(latest, current) {
@@ -1124,9 +1167,158 @@ function versionIsNewer(latest, current) {
   return false;
 }
 
-// Reads the cached latest version, prints a one-line notice if newer, and once a
-// day fire-and-forgets a background refresh. Fully best-effort — any failure is
-// swallowed so it can never affect the commit.
+// Which tier an upgrade falls into, by the literal semver field that moved.
+// Returns null when `to` is not a plain-release upgrade of `from`.
+//
+// Note the pre-1.0 consequence: at 0.x a semantically breaking 0.3.x -> 0.4.0
+// reads as a minor, so it sits in the 7-day tier rather than the 30-day one.
+// That resolves itself at 1.0.
+export function classifyVersionBump(from, to) {
+  const a = parseVersion(from);
+  const b = parseVersion(to);
+  if (!a || !b) return null;
+  if (!(b[0] > a[0] || (b[0] === a[0] && (b[1] > a[1] || (b[1] === a[1] && b[2] > a[2]))))) return null;
+  if (b[0] !== a[0]) return "major";
+  if (b[1] !== a[1]) return "minor";
+  return "patch";
+}
+
+const AFFIRMATIVE = new Set(["1", "true", "on", "yes"]);
+
+// Resolves whether the minor and major tiers are enabled. Patch is not
+// representable here on purpose: it is always on.
+//
+// The env var is treated as OFF unless it is explicitly affirmative. It used to
+// be the reverse - only 0/false/off/no disabled it - which meant
+// GFORGE_AUTO_UPDATE=disabled, =never or =2 all silently kept auto-installing
+// (issue #29). Anything that is not clearly "yes" now means no.
+export function resolveAutoUpdateSettings({ fileContent = null, env = {} } = {}) {
+  const raw = env.GFORGE_AUTO_UPDATE;
+  if (raw !== undefined && String(raw).trim() !== "") {
+    const on = AFFIRMATIVE.has(String(raw).trim().toLowerCase());
+    return { minor: on, major: on, source: "env" };
+  }
+
+  let parsed = null;
+  try {
+    parsed = fileContent ? JSON.parse(fileContent) : null;
+  } catch {
+    parsed = null; // unreadable settings fall back to the defaults
+  }
+  const autoUpdate = parsed && typeof parsed.autoUpdate === "object" ? parsed.autoUpdate : {};
+  return {
+    minor: autoUpdate.minor !== false,
+    major: autoUpdate.major !== false,
+    source: parsed ? "settings" : "default"
+  };
+}
+
+// How long a published version has been public, clamped at zero so a machine
+// with a clock set behind the registry cannot report a negative age and a clock
+// set forward cannot be used to fast-forward past a quarantine window.
+export function versionAgeMs(publishedAt, now) {
+  const published = Date.parse(String(publishedAt ?? ""));
+  if (!Number.isFinite(published)) return null;
+  return Math.max(0, now - published);
+}
+
+// Picks the version to install, or null when nothing is eligible yet.
+//
+// Within the current major it walks candidates newest-first and takes the first
+// one whose tier is enabled AND whose quarantine has elapsed - so a brand new
+// patch does not stall an older patch that has already matured.
+//
+// Crossing a major happens only via the `lts` dist-tag, and only after the
+// 30-day window. Without an `lts` tag no major ever auto-installs, which is
+// fail-safe but does make publishing that tag a release-process obligation.
+export function selectAutoUpdateTarget({ current, versions = [], distTags = {}, time = {}, now, settings }) {
+  const from = parseVersion(current);
+  if (!from) return null;
+
+  const eligible = (version) => {
+    const tier = classifyVersionBump(current, version);
+    if (!tier) return null;
+    if (tier !== "patch" && !settings[tier]) return null;
+    const age = versionAgeMs(time[version], now);
+    if (age === null || age < QUARANTINE_MS[tier]) return null;
+    return tier;
+  };
+
+  // Same-major candidates: patch and minor tiers.
+  const sameMajor = versions
+    .filter((v) => {
+      const parsed = parseVersion(v);
+      return parsed && parsed[0] === from[0];
+    })
+    .sort((a, b) => (versionIsNewer(a, b) ? -1 : 1));
+
+  let best = null;
+  for (const version of sameMajor) {
+    const tier = eligible(version);
+    if (tier) {
+      best = { version, tier };
+      break;
+    }
+  }
+
+  // A blessed major supersedes, since it is by definition the newer line.
+  const lts = distTags.lts;
+  if (lts && parseVersion(lts) && parseVersion(lts)[0] > from[0]) {
+    const tier = eligible(lts);
+    if (tier === "major") best = { version: lts, tier };
+  }
+
+  return best;
+}
+
+// What the commit path should say about a major it is NOT going to install
+// itself. A notice appears either way so a new major is never invisible; only
+// the emphasis differs, and it must not rely on colour alone (NO_COLOR, CI and
+// pipes all have to carry the distinction) - hence different wording too.
+export function describeMajorNotice({ current, distTags = {}, versions = [], settings }) {
+  const from = parseVersion(current);
+  if (!from) return null;
+
+  const newestMajor = versions
+    .filter((v) => {
+      const parsed = parseVersion(v);
+      return parsed && parsed[0] > from[0];
+    })
+    .sort((a, b) => (versionIsNewer(a, b) ? -1 : 1))[0];
+  if (!newestMajor) return null;
+
+  const lts = distTags.lts;
+  const ltsParsed = lts ? parseVersion(lts) : null;
+  const isLts = Boolean(ltsParsed && ltsParsed[0] > from[0]);
+  const version = isLts ? lts : newestMajor;
+  const willAutoInstall = isLts && settings.major;
+
+  return {
+    version,
+    isLts,
+    highlight: isLts,
+    text: isLts
+      ? `!! gforge v${version} is a new LTS major (you have v${current}).` +
+        (willAutoInstall
+          ? " It installs automatically once it has been published 30 days; run `gforge update` to take it now."
+          : " Auto-update is off for majors, so run `gforge update` to take it.")
+      : `gforge v${version} is a new major (you have v${current}). It is not marked LTS, so it will not install automatically. Run \`gforge update\` to take it.`
+  };
+}
+
+function readSettingsFile() {
+  try {
+    return readFileSync(settingsPath(), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// Reads the cache written by the background check and prints what the developer
+// needs to know: a major that will not install itself, and any unattended
+// install that has already happened. Then, once a day, fire-and-forgets a
+// refresh. Fully best-effort - any failure is swallowed so it can never affect
+// the commit.
 function maybeUpdateNotice(write) {
   try {
     let cache = null;
@@ -1135,9 +1327,36 @@ function maybeUpdateNotice(write) {
     } catch {
       cache = null;
     }
+    const known = RUNNING_VERSION[0] !== "_";
 
-    if (cache && cache.latest && RUNNING_VERSION[0] !== "_" && versionIsNewer(cache.latest, RUNNING_VERSION)) {
-      write(`\ngforge: v${cache.latest} is available (you have v${RUNNING_VERSION}). Run: gforge update\n`);
+    // An unattended install already ran. Announce it once - a mandatory update
+    // channel that leaves no trace is not acceptable for a security tool.
+    if (known && cache?.installed && cache.installed.to === RUNNING_VERSION && !cache.installed.announced) {
+      write(`\ngforge: auto-updated v${cache.installed.from} -> v${cache.installed.to}.\n`);
+      try {
+        cache.installed.announced = true;
+        writeFileSync(updateCachePath(), `${JSON.stringify(cache)}\n`);
+      } catch {
+        // At worst the notice repeats; never worth failing a commit over.
+      }
+    }
+
+    if (known && cache) {
+      const settings = resolveAutoUpdateSettings({ fileContent: readSettingsFile(), env: process.env });
+      const major = describeMajorNotice({
+        current: RUNNING_VERSION,
+        distTags: cache.distTags ?? {},
+        versions: cache.versions ?? [],
+        settings
+      });
+      if (major) {
+        const c = makePalette(colorEnabled(process.stderr));
+        write(`\n${major.highlight ? c.redBold(major.text) : major.text}\n`);
+      } else if (cache.latest && versionIsNewer(cache.latest, RUNNING_VERSION)) {
+        // Same-major update pending (still inside its quarantine window, or the
+        // tier is switched off).
+        write(`\ngforge: v${cache.latest} is available (you have v${RUNNING_VERSION}). Run: gforge update\n`);
+      }
     }
 
     const stale = !cache || (Date.now() - (cache.checkedAt || 0)) > UPDATE_CACHE_TTL_MS;
@@ -1154,49 +1373,97 @@ function maybeUpdateNotice(write) {
   }
 }
 
-// Background worker: refresh the cache and (opt-in) auto-upgrade. Detached from
-// the commit, so it may take its time.
+function appendUpdateLog(line) {
+  try {
+    // Capped by rewriting the tail: this file is advisory, so bounding it
+    // matters more than preserving every historical entry.
+    let previous = "";
+    try {
+      previous = readFileSync(updateLogPath(), "utf8");
+    } catch {
+      previous = "";
+    }
+    const kept = `${previous}${line}\n`.split("\n").slice(-200).join("\n");
+    writeFileSync(updateLogPath(), kept);
+  } catch {
+    // ignore
+  }
+}
+
+// Background worker: refresh the cache and install whatever tier is eligible.
+// Detached from the commit, so it may take its time.
 async function runUpdateCheck() {
-  const cachePath = updateCachePath();
-  let latest = null;
+  let packument = null;
   try {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 6000);
+    const timer = setTimeout(() => controller.abort(), 10000);
     try {
       const response = await fetch(REGISTRY_URL, { signal: controller.signal });
-      if (response.ok) {
-        const body = await response.json();
-        if (body && /^\d+\.\d+\.\d+/.test(String(body.version || ""))) latest = body.version;
-      }
+      if (response.ok) packument = await response.json();
     } finally {
       clearTimeout(timer);
     }
   } catch {
-    latest = null;
+    packument = null;
   }
+
+  const distTags = packument?.["dist-tags"] ?? {};
+  const time = packument?.time ?? {};
+  const versions = Object.keys(packument?.versions ?? {}).filter((v) => parseVersion(v));
+  const latest = parseVersion(distTags.latest) ? distTags.latest : null;
 
   try {
     // Always stamp checkedAt so a failed check still waits a day before retrying.
-    writeFileSync(cachePath, `${JSON.stringify({ checkedAt: Date.now(), latest: latest ?? null })}\n`);
+    writeFileSync(
+      updateCachePath(),
+      `${JSON.stringify({ checkedAt: Date.now(), latest, distTags, versions })}\n`
+    );
   } catch {
     // ignore
   }
 
-  // Auto-install is ON by default; opt out with GFORGE_AUTO_UPDATE=0/false/off/no.
-  const optOut = ["0", "false", "off", "no"].includes(String(process.env.GFORGE_AUTO_UPDATE || "").toLowerCase());
-  const safeVersion = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(String(latest || ""));
-  if (latest && safeVersion && !optOut && RUNNING_VERSION[0] !== "_" && versionIsNewer(latest, RUNNING_VERSION)) {
-    try {
-      // Install target is the constant gforge@latest (== the version we just
-      // detected); nothing registry-derived is interpolated into the command.
-      const npm = spawn("npm", ["install", "-g", "gforge@latest"], {
-        stdio: "ignore",
-        shell: process.platform === "win32"
-      });
-      await new Promise((resolve) => npm.on("close", resolve).on("error", resolve));
-    } catch {
-      // ignore; the notice will still prompt a manual `gforge update`.
+  if (RUNNING_VERSION[0] === "_" || !packument) return;
+
+  const settings = resolveAutoUpdateSettings({ fileContent: readSettingsFile(), env: process.env });
+  const target = selectAutoUpdateTarget({
+    current: RUNNING_VERSION,
+    versions,
+    distTags,
+    time,
+    now: Date.now(),
+    settings
+  });
+  if (!target) return;
+
+  // The install target is now a specific registry-derived version rather than
+  // the constant gforge@latest: a user on 1.5.2 taking a patch must get 1.5.3,
+  // not `latest`, or a patch would silently carry them across a major boundary
+  // and the whole gate would be meaningless. So this string MUST be validated
+  // before it reaches spawn - hence the hard re-check rather than trusting the
+  // selection above (issue #29).
+  if (!parseVersion(target.version)) return;
+
+  try {
+    const npm = spawn("npm", ["install", "-g", `gforge@${target.version}`], {
+      stdio: "ignore",
+      shell: process.platform === "win32"
+    });
+    const code = await new Promise((resolve) => npm.on("close", resolve).on("error", () => resolve(-1)));
+    const stamp = new Date().toISOString();
+    appendUpdateLog(
+      `${stamp} ${code === 0 ? "installed" : `failed(exit=${code})`} ${target.tier} ${RUNNING_VERSION} -> ${target.version}`
+    );
+    if (code === 0) {
+      try {
+        const cache = JSON.parse(readFileSync(updateCachePath(), "utf8"));
+        cache.installed = { from: RUNNING_VERSION, to: target.version, at: Date.now(), tier: target.tier };
+        writeFileSync(updateCachePath(), `${JSON.stringify(cache)}\n`);
+      } catch {
+        // ignore
+      }
     }
+  } catch {
+    appendUpdateLog(`${new Date().toISOString()} error ${target.tier} ${RUNNING_VERSION} -> ${target.version}`);
   }
 }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,109 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { resolveAutoUpdateSettings, settingsPath } from "./scanner.js";
+
+// Persisted user preferences, deliberately separate from state.json: the
+// installer rewrites that file on every update, so a preference stored there
+// would be wiped by the very auto-update it is meant to govern (issue #29).
+
+export async function readSettingsFile(home) {
+  try {
+    return await readFile(settingsPath(home), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// Merges the requested change into whatever is already on disk, so a future
+// setting added alongside autoUpdate is not clobbered by this command.
+export function mergeAutoUpdateSettings(fileContent, change) {
+  let existing = {};
+  try {
+    const parsed = fileContent ? JSON.parse(fileContent) : null;
+    if (parsed && typeof parsed === "object") existing = parsed;
+  } catch {
+    existing = {};
+  }
+
+  return {
+    ...existing,
+    autoUpdate: { ...(existing.autoUpdate ?? {}), ...change }
+  };
+}
+
+export async function writeAutoUpdateSettings(change, home) {
+  const path = settingsPath(home);
+  const next = mergeAutoUpdateSettings(await readSettingsFile(home), change);
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  await writeFile(path, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  return next;
+}
+
+// Patch is reported as a fixed line rather than a toggle: it is not
+// user-disableable, and saying so plainly is better than omitting it and
+// leaving people to assume --no-autoupdate covered everything.
+export function formatAutoUpdateSettings(resolved, path) {
+  const state = (on) => (on ? "on" : "off");
+  const lines = [
+    "GForge settings",
+    "",
+    `  auto-update (patch)  on         always - security and critical fixes ship here`,
+    `  auto-update (minor)  ${state(resolved.minor).padEnd(10)} 7-day quarantine before install`,
+    `  auto-update (major)  ${state(resolved.major).padEnd(10)} 30-day quarantine, and only when tagged LTS`,
+    "",
+    `  source: ${resolved.source}${resolved.source === "settings" ? ` (${path})` : ""}`
+  ];
+
+  if (resolved.source === "env") {
+    lines.push(
+      "",
+      "  Note: GFORGE_AUTO_UPDATE is set in the environment and overrides the",
+      "  stored setting. Unset it for `gforge settings` to take effect."
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+// `gforge settings` prints the current state; --no-autoupdate / --autoupdate
+// change the minor and major tiers together.
+export async function runSettingsCommand(args, streams, options = {}) {
+  const home = options.home;
+  const disable = args.includes("--no-autoupdate");
+  const enable = args.includes("--autoupdate");
+
+  if (disable && enable) {
+    streams.stderr.write("GForge: --autoupdate and --no-autoupdate cannot be combined.\n");
+    return { exitCode: 1 };
+  }
+
+  const unknown = args.slice(1).filter((a) => !["--no-autoupdate", "--autoupdate"].includes(a));
+  if (unknown.length > 0) {
+    streams.stderr.write(`GForge: unknown option for settings: ${unknown.join(", ")}\n`);
+    return { exitCode: 1 };
+  }
+
+  try {
+    if (disable || enable) {
+      const value = Boolean(enable);
+      await (options.writeAutoUpdateSettings ?? writeAutoUpdateSettings)({ minor: value, major: value }, home);
+      streams.stdout.write(
+        value
+          ? "GForge: auto-update enabled for minor and major versions.\n"
+          : "GForge: auto-update disabled for minor and major versions.\n" +
+            "        Patch updates still install automatically - that is where security fixes ship.\n"
+      );
+    }
+
+    const resolved = resolveAutoUpdateSettings({
+      fileContent: await (options.readSettingsFile ?? readSettingsFile)(home),
+      env: options.env ?? process.env
+    });
+    streams.stdout.write(`\n${formatAutoUpdateSettings(resolved, settingsPath(home))}`);
+    return { exitCode: 0 };
+  } catch (error) {
+    streams.stderr.write(`GForge settings failed\n\n${error?.message ?? error}\n`);
+    return { exitCode: 1 };
+  }
+}

--- a/test/auto-update.test.js
+++ b/test/auto-update.test.js
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  QUARANTINE_MS,
+  classifyVersionBump,
+  describeMajorNotice,
+  parseVersion,
+  resolveAutoUpdateSettings,
+  selectAutoUpdateTarget,
+  settingsPath,
+  versionAgeMs
+} from "../src/scanner.js";
+import {
+  formatAutoUpdateSettings,
+  mergeAutoUpdateSettings,
+  runSettingsCommand,
+  writeAutoUpdateSettings
+} from "../src/settings.js";
+
+const NOW = Date.parse("2026-09-02T00:00:00Z");
+const daysAgo = (n) => new Date(NOW - n * 86400000).toISOString();
+const hoursAgo = (n) => new Date(NOW - n * 3600000).toISOString();
+const ALL_ON = { minor: true, major: true };
+const ALL_OFF = { minor: false, major: false };
+
+const pick = (overrides) =>
+  selectAutoUpdateTarget({ now: NOW, settings: ALL_ON, versions: [], distTags: {}, time: {}, ...overrides });
+
+test("issue #29: quarantine windows are 48h / 7d / 30d", () => {
+  assert.equal(QUARANTINE_MS.patch, 48 * 60 * 60 * 1000);
+  assert.equal(QUARANTINE_MS.minor, 7 * 24 * 60 * 60 * 1000);
+  assert.equal(QUARANTINE_MS.major, 30 * 24 * 60 * 60 * 1000);
+});
+
+test("issue #29: classifies a bump by the literal semver field that moved", () => {
+  assert.equal(classifyVersionBump("1.5.2", "1.5.3"), "patch");
+  assert.equal(classifyVersionBump("1.5.2", "1.6.0"), "minor");
+  assert.equal(classifyVersionBump("1.5.2", "2.0.0"), "major");
+  // Pre-1.0 the semantically breaking 0.3.x -> 0.4.0 reads as a minor. That is
+  // deliberate and documented; it resolves itself at 1.0.
+  assert.equal(classifyVersionBump("0.3.7", "0.3.8"), "patch");
+  assert.equal(classifyVersionBump("0.3.7", "0.4.0"), "minor");
+  // Not an upgrade, or not a plain release.
+  assert.equal(classifyVersionBump("1.5.2", "1.5.2"), null);
+  assert.equal(classifyVersionBump("1.5.2", "1.5.1"), null);
+  assert.equal(classifyVersionBump("1.5.2", "1.6.0-beta.1"), null);
+  assert.equal(classifyVersionBump("1.5.2", "garbage"), null);
+});
+
+test("issue #29: a patch waits 48h, and nothing installs before its window elapses", () => {
+  const versions = ["1.5.2", "1.5.3"];
+  assert.equal(pick({ current: "1.5.2", versions, time: { "1.5.3": hoursAgo(1) } }), null);
+  assert.equal(pick({ current: "1.5.2", versions, time: { "1.5.3": hoursAgo(47) } }), null);
+  assert.deepEqual(pick({ current: "1.5.2", versions, time: { "1.5.3": hoursAgo(49) } }), {
+    version: "1.5.3",
+    tier: "patch"
+  });
+});
+
+test("issue #29: a brand new patch does not stall an older one that has matured", () => {
+  // Otherwise a rapid release cadence could keep a machine permanently pinned:
+  // every candidate would always be inside its own window.
+  const target = pick({
+    current: "1.5.1",
+    versions: ["1.5.1", "1.5.2", "1.5.3"],
+    time: { "1.5.2": daysAgo(10), "1.5.3": hoursAgo(1) }
+  });
+  assert.deepEqual(target, { version: "1.5.2", tier: "patch" });
+});
+
+test("issue #29: minor waits 7 days and honours the user's setting", () => {
+  const versions = ["1.5.2", "1.6.0"];
+  assert.equal(pick({ current: "1.5.2", versions, time: { "1.6.0": daysAgo(3) } }), null);
+  assert.deepEqual(pick({ current: "1.5.2", versions, time: { "1.6.0": daysAgo(10) } }), {
+    version: "1.6.0",
+    tier: "minor"
+  });
+  assert.equal(
+    pick({ current: "1.5.2", versions, time: { "1.6.0": daysAgo(10) }, settings: ALL_OFF }),
+    null
+  );
+});
+
+test("issue #29: patch installs even when the user disabled auto-update", () => {
+  // The one tier that is not disableable - this is where security and critical
+  // fixes to GForge itself ship.
+  assert.deepEqual(
+    pick({ current: "1.5.2", versions: ["1.5.2", "1.5.3"], time: { "1.5.3": daysAgo(3) }, settings: ALL_OFF }),
+    { version: "1.5.3", tier: "patch" }
+  );
+});
+
+test("issue #29: a major only auto-installs when tagged LTS, after 30 days", () => {
+  const versions = ["1.5.2", "2.0.0"];
+
+  // No lts tag: never, however old it is. Fail-safe, but it does mean
+  // publishing the tag is a release-process obligation.
+  assert.equal(pick({ current: "1.5.2", versions, time: { "2.0.0": daysAgo(60) } }), null);
+
+  // Tagged, but still inside the window.
+  assert.equal(
+    pick({ current: "1.5.2", versions, distTags: { lts: "2.0.0" }, time: { "2.0.0": daysAgo(10) } }),
+    null
+  );
+
+  // Tagged and matured.
+  assert.deepEqual(
+    pick({ current: "1.5.2", versions, distTags: { lts: "2.0.0" }, time: { "2.0.0": daysAgo(60) } }),
+    { version: "2.0.0", tier: "major" }
+  );
+
+  // Disabled by the user.
+  assert.equal(
+    pick({
+      current: "1.5.2",
+      versions,
+      distTags: { lts: "2.0.0" },
+      time: { "2.0.0": daysAgo(60) },
+      settings: ALL_OFF
+    }),
+    null
+  );
+});
+
+test("issue #29: an eligible LTS major supersedes an eligible patch", () => {
+  assert.deepEqual(
+    pick({
+      current: "1.5.2",
+      versions: ["1.5.2", "1.5.3", "2.0.0"],
+      distTags: { lts: "2.0.0" },
+      time: { "1.5.3": daysAgo(3), "2.0.0": daysAgo(60) }
+    }),
+    { version: "2.0.0", tier: "major" }
+  );
+});
+
+test("issue #29: a version with no publish time is never eligible", () => {
+  // Quarantine cannot be evaluated without a timestamp, so it fails closed
+  // rather than installing something of unknown age.
+  assert.equal(pick({ current: "1.5.2", versions: ["1.5.2", "1.5.3"], time: {} }), null);
+  assert.equal(versionAgeMs(undefined, NOW), null);
+  assert.equal(versionAgeMs("not-a-date", NOW), null);
+});
+
+test("issue #29: a clock set behind the registry cannot produce a negative age", () => {
+  // Clamped at zero, so skew can only ever make a version look younger (and
+  // therefore wait longer) - never old enough to skip its window.
+  assert.equal(versionAgeMs(new Date(NOW + 86400000).toISOString(), NOW), 0);
+  assert.equal(versionAgeMs(new Date(NOW - 3600000).toISOString(), NOW), 3600000);
+});
+
+test("issue #29: GFORGE_AUTO_UPDATE no longer fails open on an unrecognised value", () => {
+  // The bug: only 0/false/off/no disabled it, so `disabled`, `never` and `2`
+  // all silently kept auto-installing. Anything not clearly affirmative is now
+  // treated as off.
+  for (const value of ["1", "true", "on", "yes", "YES", "On"]) {
+    const resolved = resolveAutoUpdateSettings({ env: { GFORGE_AUTO_UPDATE: value } });
+    assert.equal(resolved.minor, true, value);
+    assert.equal(resolved.major, true, value);
+  }
+  for (const value of ["0", "false", "off", "no", "disabled", "never", "2", "garbage"]) {
+    const resolved = resolveAutoUpdateSettings({ env: { GFORGE_AUTO_UPDATE: value } });
+    assert.equal(resolved.minor, false, value);
+    assert.equal(resolved.major, false, value);
+  }
+});
+
+test("issue #29: settings default to on, and a corrupt file falls back to the default", () => {
+  assert.deepEqual(resolveAutoUpdateSettings({}), { minor: true, major: true, source: "default" });
+  assert.deepEqual(resolveAutoUpdateSettings({ fileContent: "{not json" }), {
+    minor: true,
+    major: true,
+    source: "default"
+  });
+
+  const off = resolveAutoUpdateSettings({ fileContent: JSON.stringify({ autoUpdate: { minor: false, major: false } }) });
+  assert.equal(off.minor, false);
+  assert.equal(off.major, false);
+  assert.equal(off.source, "settings");
+
+  // An env var beats the stored setting, in both directions.
+  const envOn = resolveAutoUpdateSettings({
+    fileContent: JSON.stringify({ autoUpdate: { minor: false, major: false } }),
+    env: { GFORGE_AUTO_UPDATE: "1" }
+  });
+  assert.equal(envOn.minor, true);
+  assert.equal(envOn.source, "env");
+});
+
+test("issue #29: a new major always produces a notice, highlighted only when LTS", () => {
+  const versions = ["1.5.2", "2.0.0"];
+
+  const lts = describeMajorNotice({ current: "1.5.2", versions, distTags: { lts: "2.0.0" }, settings: ALL_ON });
+  assert.equal(lts.highlight, true);
+  assert.match(lts.text, /LTS major/);
+  // The distinction must survive NO_COLOR / CI / pipes, so it is carried in the
+  // wording too, not by colour alone.
+  assert.match(lts.text, /^!!/);
+
+  const ltsOff = describeMajorNotice({ current: "1.5.2", versions, distTags: { lts: "2.0.0" }, settings: ALL_OFF });
+  assert.equal(ltsOff.highlight, true);
+  assert.match(ltsOff.text, /Auto-update is off for majors/);
+
+  const plain = describeMajorNotice({ current: "1.5.2", versions, distTags: {}, settings: ALL_ON });
+  assert.equal(plain.highlight, false);
+  assert.match(plain.text, /not marked LTS/);
+  assert.equal(/^!!/.test(plain.text), false);
+
+  // Nothing to say when there is no newer major.
+  assert.equal(describeMajorNotice({ current: "2.0.0", versions, distTags: {}, settings: ALL_ON }), null);
+});
+
+test("issue #29: parseVersion accepts only plain releases", () => {
+  assert.deepEqual(parseVersion("1.5.2"), [1, 5, 2]);
+  assert.deepEqual(parseVersion(" 0.3.7 "), [0, 3, 7]);
+  for (const bad of ["1.5", "1.5.2-beta.1", "v1.5.2", "1.5.2+build", "", null, undefined, "latest"]) {
+    assert.equal(parseVersion(bad), null, String(bad));
+  }
+});
+
+test("issue #29: settings live outside state.json so an update cannot wipe them", () => {
+  // installManagedHooks rewrites state.json on every update; a preference
+  // stored there would be destroyed by the very auto-update it governs.
+  const path = settingsPath("/home/example");
+  assert.match(path, /\.gforge[/\\]settings\.json$/);
+  assert.equal(path.includes("state.json"), false);
+});
+
+test("issue #29: writing a setting preserves unrelated keys already on disk", () => {
+  const existing = JSON.stringify({ somethingElse: 42, autoUpdate: { minor: false } });
+  const merged = mergeAutoUpdateSettings(existing, { major: false });
+
+  assert.equal(merged.somethingElse, 42);
+  assert.deepEqual(merged.autoUpdate, { minor: false, major: false });
+  // A corrupt file is replaced rather than throwing.
+  assert.deepEqual(mergeAutoUpdateSettings("{not json", { minor: false }), { autoUpdate: { minor: false } });
+});
+
+test("issue #29: gforge settings --no-autoupdate persists and reports the state", async () => {
+  const home = await mkdtemp(join(tmpdir(), "gforge-settings-"));
+  const streams = createStreams();
+
+  const result = await runSettingsCommand(["settings", "--no-autoupdate"], streams, { home, env: {} });
+
+  assert.equal(result.exitCode, 0);
+  assert.match(streams.out(), /auto-update disabled for minor and major/);
+  // The report must say plainly that patch is unaffected, or people will assume
+  // the flag covered everything.
+  assert.match(streams.out(), /Patch updates still install automatically/);
+  assert.match(streams.out(), /auto-update \(minor\)\s+off/);
+  assert.match(streams.out(), /auto-update \(patch\)\s+on\s+always/);
+
+  const onDisk = JSON.parse(await readFile(settingsPath(home), "utf8"));
+  assert.deepEqual(onDisk.autoUpdate, { minor: false, major: false });
+});
+
+test("issue #29: gforge settings warns when the env var overrides the stored value", async () => {
+  const home = await mkdtemp(join(tmpdir(), "gforge-settings-"));
+  await writeAutoUpdateSettings({ minor: true, major: true }, home);
+
+  const streams = createStreams();
+  const result = await runSettingsCommand(["settings"], streams, { home, env: { GFORGE_AUTO_UPDATE: "0" } });
+
+  assert.equal(result.exitCode, 0);
+  // Without this the user re-enables auto-update, sees no effect, and has no
+  // way to tell why.
+  assert.match(streams.out(), /GFORGE_AUTO_UPDATE is set in the environment/);
+  assert.match(streams.out(), /source: env/);
+});
+
+test("issue #29: contradictory or unknown settings flags fail rather than guessing", async () => {
+  const home = await mkdtemp(join(tmpdir(), "gforge-settings-"));
+
+  const both = createStreams();
+  assert.equal((await runSettingsCommand(["settings", "--autoupdate", "--no-autoupdate"], both, { home })).exitCode, 1);
+  assert.match(both.err(), /cannot be combined/);
+
+  const bogus = createStreams();
+  assert.equal((await runSettingsCommand(["settings", "--bogus"], bogus, { home })).exitCode, 1);
+  assert.match(bogus.err(), /unknown option/);
+});
+
+test("issue #29: the settings report names the tier rules so they are discoverable", () => {
+  const output = formatAutoUpdateSettings({ minor: true, major: true, source: "default" }, "/h/.gforge/settings.json");
+  assert.match(output, /7-day quarantine/);
+  assert.match(output, /30-day quarantine, and only when tagged LTS/);
+  assert.match(output, /security and critical fixes ship here/);
+});
+
+function createStreams() {
+  let out = "";
+  let err = "";
+  return {
+    stdout: { write: (s) => { out += s; } },
+    stderr: { write: (s) => { err += s; } },
+    out: () => out,
+    err: () => err
+  };
+}


### PR DESCRIPTION
Auto-update stays on by default - a stale scanner is its own security problem, and this project ships detection fixes continuously. Rather than turning it off, the blast radius of a compromised publish is now bounded by a quarantine window per tier:

  patch  48h,    always on
  minor  7 days, user-disableable
  major  30 days AND tagged `lts`, user-disableable

The patch tier keeps a real if short window rather than installing immediately. Semver is a claim made by the publisher, and in this threat model the publisher is the compromised party - a hostile release would be published as a patch, precisely because that tier moves fastest. A zero-delay patch channel would leave the quarantine guarding doors an attacker walks straight past. 48h still lands a genuine fix the same week. Patch remains non-disableable because that is where security fixes to GForge itself ship.

Majors never install silently: a notice always prints, highlighted when the release is tagged `lts` and plain when it is not, and only a tagged LTS major auto-installs. Without an `lts` dist-tag no major ever installs automatically - fail-safe, but it does make publishing that tag a release-process obligation.

Two consequences worth calling out for review:

- The daily check moves from /gforge/latest to the full packument. Measured: only the full response carries the `time` map quarantine needs and the `dist-tags` the LTS rule needs (33KB vs 1KB, once a day, off the commit path).

- The install target can no longer be the constant gforge@latest. A user on 1.5.2 taking a patch must get 1.5.3, or a patch would silently carry them across a major boundary and the gate would be meaningless. So a registry-derived version is now interpolated into the npm argv, and parseVersion() became a hard precondition immediately before spawn rather than the advisory check it was.

Also fixes three defects found while investigating, wrong under any policy:

- The opt-out failed open. Only 0/false/off/no disabled auto-update, so GFORGE_AUTO_UPDATE=disabled, =never and =2 all silently kept auto-installing. Inverted to an affirmative allowlist.
- An env var was the wrong home for the setting: the hook runs as git -> sh -> node and does not inherit a shell profile from a GUI client, so GFORGE_AUTO_UPDATE=0 in .zshrc could be silently ineffective. Added `gforge settings --no-autoupdate`, persisted to ~/.gforge/settings.json - deliberately not state.json, which the installer rewrites on every update and would clobber.
- Unattended installs left no trace at all (stdio ignored, errors swallowed). They now append to a capped ~/.gforge/update-log and are announced once on the next commit.

Quarantine age is clamped at zero, which stops a clock set *behind* the registry from reporting a negative age. It is not a defence against a clock set forward: clamping can only raise a value, so a machine 30 days fast sees a patch published an hour ago as 30 days old and clears every window, the 30-day major one included. Accepted rather than fixed - anyone who can set the system clock can edit `~/.gforge/settings.json` too - but not claimed as a guarantee. (Corrected after review; the earlier wording here and in the `versionAgeMs` comment overstated it.)

---

## Concurrency fix (#84), added in a follow-up commit

Review of the above found a defect in it: the background worker had no lock, so
two commits in quick succession both saw the cache as stale - the first worker
had not written it yet - and each spawned a worker that reached `npm install -g`.
Two processes writing the same global package directory at once. Reproduced end
to end against a real registry fetch with a stub npm on PATH: 2 of 2 concurrent
runs invoked the installer.

Fixing it took three parts, and stress-running six concurrent workers is what
found the last two - each intermediate fix looked correct and still raced:

| Attempt | Double installs |
| --- | --- |
| exclusive-create (`wx`) lock, held for the whole run | 1 in 3 |
| + verify what the stale-lock steal actually took | 1 in 12 |
| + recheck cache freshness after locking | **0 / 25 rounds** |

- **Stale-lock steal.** Renaming looked like a sufficient arbiter but is not:
  once one process has stolen the dead lock and claimed a fresh one, a second
  stealer's rename carries off *that live lock* instead. A mis-steal is now
  detected and put back, so the worst case is a skipped check that retries -
  never a second installer.
- **Late arrival.** Mutual exclusion alone never addressed this one. A worker
  that starts late acquires the lock cleanly *after* the winner has finished and
  released it, then repeats the work - it carries its own baked-in
  `RUNNING_VERSION` and cannot tell the install already happened. The freshly
  written cache is the only signal, hence the double-checked recheck.

A stale lock is taken over after 15 minutes so a crashed worker cannot disable
updates permanently, and an unreadable one counts as abandoned. The commit path
also skips spawning a worker while one is running, so a slow install no longer
forks a doomed process on every commit.

Two things #84 did not mention, both fixed here:

- `appendUpdateLog` was racy in the same way - read-modify-write, so the original
  repro produced two installs but only **one** log line. Holding the lock across
  the whole run closes it.
- The settings tests added in the first commit were leaving 12 temp directories
  behind per run, which is the hygiene gap #55 describes. Cleaned up rather than
  left to make that issue worse.

Verified after the fix: 0 double installs across 25 stress rounds of six
concurrent workers, with and without a pre-existing stale lock, plus deliberately
late-arriving workers; a fresh lock is never stolen; and a genuinely stale cache
25h later still updates, so the lock does not over-block.

Note the new unit tests fail at module level against pre-fix code (the exports do
not exist yet), so the behavioural regression proof is the stress harness rather
than those assertions.

## Test plan

- [x] `npm test` - 160/160 passing (27 in the auto-update suite)
- [x] `npm run package:check` - passes
- [x] End-to-end against the real registry with a stub npm: bug reproduced 2/2
      before, 0/25 stress rounds after
- [x] Lock semantics covered directly: free/held/stale boundaries, corrupt lock
      treated as abandoned, release idempotent, no stray takeover files
- [x] Temp directories created by this suite are cleaned up

## Review follow-up (@dwijacharya)

Three points raised, all three reproduced before acting on them.

**1. The registry reached a shell-parsed spawn (fixed).** `registry=https://registry.npmjs.org/&ver&`
in `.npmrc` comes back from `npm config get registry` verbatim, `normalizeRegistryUrl` accepted it
because it is a well-formed https URL, and it was interpolated into `--registry=`. On Windows npm is
`npm.cmd` and can only be spawned through a shell, and `shell: true` concatenates argv without
escaping - Node warns about exactly this shape as DEP0190. A regression, as noted: the first commit
was deliberate that only a validated numeric version crossed into the spawn, and the registry was
added after that.

Fixed structurally, per the suggestion - npm reads `npm_config_*` from the environment at higher
precedence than any `.npmrc`, so the registry goes there and never enters argv. #79's pin is
unaffected. Rejecting shell metacharacters in `normalizeRegistryUrl` is kept as a second lock, since
the scheme check let `&`, `|`, `;` and `$(` straight through.

Measured with a stub npm and a local packument server:

| | npm's argv |
| --- | --- |
| before, hostile `.npmrc` | `install -g --registry=http://h/&INJECTED&/ gforge@1.0.1` |
| after, hostile `.npmrc` | npm never invoked |
| after, real mirror | `install -g gforge@1.0.1`, `npm_config_registry` set in env |

**2. `Fixes #83` with nothing in the diff (now resolved).** Correct at the time of review. PR #101
merged into this branch about five hours later and `describeUpdateOutcome` / `readInstalledEngineVersion`
now do the check the issue describes: a zero exit from npm is confirmed against the version baked
into `~/.gforge/hooks/gforge-scan.mjs` before it counts as an update, and the mismatch is recorded as
`hooksStale` and announced on the next commit.

**3. The forward-clock claim (fixed in wording).** Right, and it reproduces exactly as described -
against a patch published an hour ago, an honest clock holds it, 30 days fast installs it, 31 days
fast clears the major window. No code change, as you said; the claim is gone from both the body above
and the `versionAgeMs` comment.

Test coverage for the gap you flagged: an accepted registry value is now pinned as unable to carry
shell syntax, using `https://registry.npmjs.org/&ver&` as the case. It fails against pre-fix code on
that exact value. 165 tests pass.

Fixes #29
Fixes #84

Also carries the registry fix from PR #100, which stacks on this branch because
the quarantine logic it corrects does not exist on master. Listed here so the
issue closes when this merges - a closing keyword on a PR that does not target
the default branch does not create the link on its own.

Fixes #79
Fixes #83

